### PR TITLE
[FE] Package version field searches by 100 items only

### DIFF
--- a/packages/editor/src/routes/root/EditorPage/ProjectEditorPage/ProjectEditorToolbar/PublishProjectVersionDialog.tsx
+++ b/packages/editor/src/routes/root/EditorPage/ProjectEditorPage/ProjectEditorToolbar/PublishProjectVersionDialog.tsx
@@ -77,7 +77,7 @@ const PublishProjectVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, set
 
   const defaultPackageKey = usePackageKey()
   const [versionsFilter, setVersionsFilter] = useState('')
-  const { versions, isLoading: areVersionsLoading } = usePackageVersions({ packageKey: defaultPackageKey, textFilter: versionsFilter })
+  const { versions, areVersionsLoading } = usePackageVersions({ packageKey: defaultPackageKey, textFilter: versionsFilter })
 
   const previousVersionOptions = usePreviousVersionOptions()
 

--- a/packages/editor/src/routes/root/EditorPage/ProjectEditorPage/ProjectEditorToolbar/PublishProjectVersionDialog.tsx
+++ b/packages/editor/src/routes/root/EditorPage/ProjectEditorPage/ProjectEditorToolbar/PublishProjectVersionDialog.tsx
@@ -77,7 +77,7 @@ const PublishProjectVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, set
 
   const defaultPackageKey = usePackageKey()
   const [versionsFilter, setVersionsFilter] = useState('')
-  const [versions, areVersionsLoading] = usePackageVersions({ packageKey: defaultPackageKey, textFilter: versionsFilter })
+  const { versions, isLoading: areVersionsLoading } = usePackageVersions({ packageKey: defaultPackageKey, textFilter: versionsFilter })
 
   const previousVersionOptions = usePreviousVersionOptions()
 

--- a/packages/editor/src/routes/root/EditorPage/ProjectEditorPage/usePreviousVersionOptions.ts
+++ b/packages/editor/src/routes/root/EditorPage/ProjectEditorPage/usePreviousVersionOptions.ts
@@ -22,7 +22,7 @@ import { usePackageKey } from '../../usePackage'
 
 export function usePreviousVersionOptions(): VersionKey[] {
   const defaultPackageKey = usePackageKey()
-  const [versions] = usePackageVersions({ packageKey: defaultPackageKey, status: RELEASE_VERSION_STATUS })
+  const { versions } = usePackageVersions({ packageKey: defaultPackageKey, status: RELEASE_VERSION_STATUS })
 
   return useMemo(() => ([
     NO_PREVIOUS_RELEASE_VERSION_OPTION,

--- a/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/SearchFilters.tsx
+++ b/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/SearchFilters.tsx
@@ -171,7 +171,7 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
     setPackagesFilter(value), DEFAULT_DEBOUNCE), [])
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const { versions: packageVersions, isInitialLoading } = usePackageVersions({
+  const { versions: packageVersions, areVersionsInitiallyLoading } = usePackageVersions({
     packageKey: packageKey,
     enabled: enabledFilters && !!packageKey,
     textFilter: versionsFilter,
@@ -519,10 +519,10 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
           render={({ field }) => <Autocomplete
             forcePopupIcon={false}
             value={field.value ?? null}
-            options={packageKey ? handledVersions?.map(version => version.key) : []}
+            options={handledVersions?.map(version => version.key)}
             isOptionEqualToValue={(option, value) => option === value}
             filterOptions={disableAutocompleteSearch}
-            loading={isInitialLoading}
+            loading={areVersionsInitiallyLoading}
             renderInput={(params) => <TextField {...field} {...params} label="Package version"/>}
             onInputChange={onVersionInputChange}
             onChange={(_, version) => setValue('version', version ?? '')}
@@ -689,7 +689,7 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
         </Button>
       </Box>
     </>
-  ), [activeTab, apiSearchMode, apiType, apiTypeFormMap, control, errors.apiType, formatPublicationDate, groups, handledVersions, isWorkspacesLoading, isGroupsLoading, isPackagesLoading, isInitialLoading, packageKey, packages, reset, setValue, workspaceKey, workspaces, onGroupInputChange, onPackageInputChange, onWorkspaceInputChange, onVersionInputChange])
+  ), [activeTab, apiSearchMode, apiType, apiTypeFormMap, control, errors.apiType, formatPublicationDate, groups, handledVersions, isWorkspacesLoading, isGroupsLoading, isPackagesLoading, areVersionsInitiallyLoading, packages, reset, setValue, workspaceKey, workspaces, onGroupInputChange, onPackageInputChange, onWorkspaceInputChange, onVersionInputChange])
 })
 
 function ScopesAutocomplete<T extends Key>({

--- a/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/SearchFilters.tsx
+++ b/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/SearchFilters.tsx
@@ -84,7 +84,7 @@ type FiltersData = Partial<{
   workspace: Package | null
   group: Package | null
   pkg: Package | null
-  versions: Key
+  version: Key
   statuses: VersionStatus[]
   publicationDatePeriod: string[]
   apiType: ApiType
@@ -124,7 +124,7 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
     operationTypes,
     apiType,
     methods,
-    versions,
+    version,
     statuses,
     publicationDatePeriod,
     detailedScope,
@@ -170,8 +170,15 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
   const onPackageInputChange = useMemo(() => debounce((_: SyntheticEvent, value: string) =>
     setPackagesFilter(value), DEFAULT_DEBOUNCE), [])
 
-  const [packageVersions] = usePackageVersions({ packageKey })
+  const [versionsFilter, setVersionsFilter] = useState('')
+  const { versions: packageVersions, isInitialLoading } = usePackageVersions({
+    packageKey: packageKey,
+    enabled: enabledFilters && !!packageKey,
+    textFilter: versionsFilter,
+  })
   const handledVersions = handleVersionsRevision(packageVersions)
+  const onVersionInputChange = useMemo(() => debounce((_: SyntheticEvent, value: string) =>
+    setVersionsFilter(value), DEFAULT_DEBOUNCE), [])
 
   const ref = useRef<DatePickerRef>()
 
@@ -210,7 +217,7 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
   const onSubmit = useMemo(
     () => handleSubmit((value) => {
       const {
-        versions,
+        version,
         statuses,
         publicationDatePeriod,
         apiType,
@@ -220,7 +227,7 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
         methods,
       } = value
 
-      const versionData = versions ? [versions] : []
+      const versionData = version ? [version] : []
       const packageIdsData = (): string[] => {
         if (packageKey) {
           return [packageKey]
@@ -283,7 +290,7 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
       methods,
       scope,
       statuses,
-      versions,
+      version,
       publicationDatePeriod,
     ],
   )
@@ -507,15 +514,18 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
         </Tooltip>
 
         <Controller
-          name="versions"
+          name="version"
           control={control}
           render={({ field }) => <Autocomplete
             forcePopupIcon={false}
             value={field.value ?? null}
-            options={handledVersions?.map(version => version.key)}
+            options={packageKey ? handledVersions?.map(version => version.key) : []}
             isOptionEqualToValue={(option, value) => option === value}
+            filterOptions={disableAutocompleteSearch}
+            loading={isInitialLoading}
             renderInput={(params) => <TextField {...field} {...params} label="Package version"/>}
-            onChange={(_, version) => setValue('versions', version ?? '')}
+            onInputChange={onVersionInputChange}
+            onChange={(_, version) => setValue('version', version ?? '')}
             data-testid="PackageVersionAutocomplete"
           />}
         />
@@ -679,7 +689,7 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
         </Button>
       </Box>
     </>
-  ), [activeTab, apiSearchMode, apiType, apiTypeFormMap, control, errors.apiType, formatPublicationDate, groups, handledVersions, isWorkspacesLoading, isGroupsLoading, isPackagesLoading, packages, reset, setValue, workspaceKey, workspaces, onGroupInputChange, onPackageInputChange, onWorkspaceInputChange])
+  ), [activeTab, apiSearchMode, apiType, apiTypeFormMap, control, errors.apiType, formatPublicationDate, groups, handledVersions, isWorkspacesLoading, isGroupsLoading, isPackagesLoading, isInitialLoading, packageKey, packages, reset, setValue, workspaceKey, workspaces, onGroupInputChange, onPackageInputChange, onWorkspaceInputChange, onVersionInputChange])
 })
 
 function ScopesAutocomplete<T extends Key>({

--- a/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
@@ -74,7 +74,7 @@ const CopyPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpe
   const [targetVersion, setTargetVersion] = useState<Key>('')
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const [versionsWithRevisions, areVersionsLoading] = usePackageVersions({
+  const { versions: versionsWithRevisions, isLoading: areVersionsLoading } = usePackageVersions({
     packageKey: targetPackage?.key,
     enabled: !!targetPackage,
     textFilter: versionsFilter,
@@ -114,7 +114,7 @@ const CopyPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpe
     }
   }, [currentVersionConfig, currentPackage?.parents])
 
-  const [targetPackagePreviousVersions] = usePackageVersions({
+  const { versions: targetPackagePreviousVersions } = usePackageVersions({
     packageKey: targetPackage?.key,
     enabled: !!targetPackage,
     status: RELEASE_VERSION_STATUS,

--- a/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
@@ -74,7 +74,7 @@ const CopyPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpe
   const [targetVersion, setTargetVersion] = useState<Key>('')
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const { versions: versionsWithRevisions, isLoading: areVersionsLoading } = usePackageVersions({
+  const { versions: versionsWithRevisions, areVersionsLoading } = usePackageVersions({
     packageKey: targetPackage?.key,
     enabled: !!targetPackage,
     textFilter: versionsFilter,

--- a/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishDashboardVersionFromCSVDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishDashboardVersionFromCSVDialog.tsx
@@ -59,7 +59,7 @@ const PublishDashboardVersionFromCSVPopup: FC<PopupProps> = memo<PopupProps>(({ 
   const releaseVersionPattern = useMemo(() => packageObj?.releaseVersionPattern, [packageObj])
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const { versions, isLoading: areVersionsLoading } = usePackageVersions({ textFilter: versionsFilter })
+  const { versions, areVersionsLoading } = usePackageVersions({ textFilter: versionsFilter })
   const [targetVersion, setTargetVersion] = useState<Key>('')
   const isEditingVersion = !!versionId && versionId !== SPECIAL_VERSION_KEY
 

--- a/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishDashboardVersionFromCSVDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishDashboardVersionFromCSVDialog.tsx
@@ -59,7 +59,7 @@ const PublishDashboardVersionFromCSVPopup: FC<PopupProps> = memo<PopupProps>(({ 
   const releaseVersionPattern = useMemo(() => packageObj?.releaseVersionPattern, [packageObj])
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const [versions, areVersionsLoading] = usePackageVersions({ textFilter: versionsFilter })
+  const { versions, isLoading: areVersionsLoading } = usePackageVersions({ textFilter: versionsFilter })
   const [targetVersion, setTargetVersion] = useState<Key>('')
   const isEditingVersion = !!versionId && versionId !== SPECIAL_VERSION_KEY
 
@@ -89,8 +89,8 @@ const PublishDashboardVersionFromCSVPopup: FC<PopupProps> = memo<PopupProps>(({ 
     }
   }, [currentVersion, isEditingVersion, versionId])
 
-  const [previousVersion] = usePackageVersions({ status: RELEASE_VERSION_STATUS })
-  const previousVersionOptions = usePreviousVersionOptions(previousVersion)
+  const { versions: previousVersions } = usePackageVersions({ status: RELEASE_VERSION_STATUS })
+  const previousVersionOptions = usePreviousVersionOptions(previousVersions)
 
   const { handleSubmit, control, setValue, formState } = useForm<VersionFormData>({ defaultValues })
 

--- a/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishPackageVersionDialog.tsx
@@ -61,7 +61,7 @@ const PublishPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, set
   const releaseVersionPattern = useMemo(() => packageObj?.releaseVersionPattern, [packageObj])
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const { versions, isLoading: areVersionsLoading } = usePackageVersions({ textFilter: versionsFilter })
+  const { versions, areVersionsLoading } = usePackageVersions({ textFilter: versionsFilter })
   const { filesWithLabels } = useFiles()
   const isEditingVersion = !!versionId && versionId !== SPECIAL_VERSION_KEY
 

--- a/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishPackageVersionDialog.tsx
@@ -61,7 +61,7 @@ const PublishPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, set
   const releaseVersionPattern = useMemo(() => packageObj?.releaseVersionPattern, [packageObj])
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const [versions, areVersionsLoading] = usePackageVersions({ textFilter: versionsFilter })
+  const { versions, isLoading: areVersionsLoading } = usePackageVersions({ textFilter: versionsFilter })
   const { filesWithLabels } = useFiles()
   const isEditingVersion = !!versionId && versionId !== SPECIAL_VERSION_KEY
 
@@ -88,8 +88,8 @@ const PublishPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, set
     }
   }, [currentVersion, isEditingVersion, versionId])
 
-  const [previousVersion] = usePackageVersions({ status: RELEASE_VERSION_STATUS })
-  const previousVersionOptions = usePreviousVersionOptions(previousVersion)
+  const { versions: previousVersions } = usePackageVersions({ status: RELEASE_VERSION_STATUS })
+  const previousVersionOptions = usePreviousVersionOptions(previousVersions)
 
   const { handleSubmit, control, setValue, formState } = useForm<VersionFormData>({ defaultValues })
 

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/GeneralPackageSettingsTab/GeneralPackageSettingsTabEditor.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/GeneralPackageSettingsTab/GeneralPackageSettingsTabEditor.tsx
@@ -72,7 +72,7 @@ export const GeneralPackageSettingsTabEditor: FC<PackageSettingsTabProps> = memo
   const editable = useEditableGeneralPackageSettingsTabContent()
   const setEditable = useSetEditableGeneralPackageSettingsTabContent()
   const [updatePackage, isUpdateLoading, isSuccess] = useUpdatePackage()
-  const [previousReleaseVersions] = usePackageVersions({
+  const { versions: previousReleaseVersions } = usePackageVersions({
     packageKey: key,
     status: RELEASE_VERSION_STATUS,
   })

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
@@ -49,7 +49,7 @@ export const PackageVersionsTable: FC<PackageVersionsTableProps> = memo<PackageV
     onDelete, onEdit, searchValue,
   } = props
 
-  const [versions, isLoading, fetchNextPage, isNextPageFetching, hasNextPage] = usePackageVersions({
+  const { versions, isLoading, fetchNextPage, isFetchingNextPage, hasNextPage } = usePackageVersions({
     packageKey: packageKey,
     status: status,
     textFilter: searchValue,
@@ -60,7 +60,7 @@ export const PackageVersionsTable: FC<PackageVersionsTableProps> = memo<PackageV
   ), [versions])
 
   const ref = useRef<HTMLDivElement>(null)
-  useIntersectionObserver(ref, isNextPageFetching, hasNextPage, fetchNextPage)
+  useIntersectionObserver(ref, isFetchingNextPage, hasNextPage, fetchNextPage)
 
   return (
     <Placeholder

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
@@ -49,7 +49,7 @@ export const PackageVersionsTable: FC<PackageVersionsTableProps> = memo<PackageV
     onDelete, onEdit, searchValue,
   } = props
 
-  const { versions, isLoading, fetchNextPage, isFetchingNextPage, hasNextPage } = usePackageVersions({
+  const { versions, areVersionsLoading, fetchNextPage, isFetchingNextPage, hasNextPage } = usePackageVersions({
     packageKey: packageKey,
     status: status,
     textFilter: searchValue,
@@ -64,7 +64,7 @@ export const PackageVersionsTable: FC<PackageVersionsTableProps> = memo<PackageV
 
   return (
     <Placeholder
-      invisible={isNotEmpty(filteredVersions) || isLoading}
+      invisible={isNotEmpty(filteredVersions) || areVersionsLoading}
       area={NAVIGATION_PLACEHOLDER_AREA}
       message={searchValue ? NO_SEARCH_RESULTS : 'No versions to display'}
     >
@@ -79,7 +79,7 @@ export const PackageVersionsTable: FC<PackageVersionsTableProps> = memo<PackageV
         />}
         hasNextPage={hasNextPage}
         refObject={ref}
-        isLoading={isLoading}
+        isLoading={areVersionsLoading}
       />
     </Placeholder>
   )

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/CompareVersionsDialog/CompareVersionsDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/CompareVersionsDialog/CompareVersionsDialog.tsx
@@ -299,11 +299,11 @@ function useDialogData(
     textFilter: changedPackageInputValue,
   })
 
-  const { versions: originalVersions, isLoading: isOriginalPackageVersionsLoading } = usePackageVersions({
+  const { versions: originalVersions, areVersionsLoading: isOriginalPackageVersionsLoading } = usePackageVersions({
     packageKey: originalPackage?.key,
     textFilter: originalPackageVersionInputValue,
   })
-  const { versions: changedVersions, isLoading: isChangedPackageVersionsLoading } = usePackageVersions({
+  const { versions: changedVersions, areVersionsLoading: isChangedPackageVersionsLoading } = usePackageVersions({
     packageKey: changedPackage?.key,
     textFilter: changedPackageVersionInputValue,
   })

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/CompareVersionsDialog/CompareVersionsDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/CompareVersionsDialog/CompareVersionsDialog.tsx
@@ -299,11 +299,11 @@ function useDialogData(
     textFilter: changedPackageInputValue,
   })
 
-  const [originalVersions, isOriginalPackageVersionsLoading] = usePackageVersions({
+  const { versions: originalVersions, isLoading: isOriginalPackageVersionsLoading } = usePackageVersions({
     packageKey: originalPackage?.key,
     textFilter: originalPackageVersionInputValue,
   })
-  const [changedVersions, isChangedPackageVersionsLoading] = usePackageVersions({
+  const { versions: changedVersions, isLoading: isChangedPackageVersionsLoading } = usePackageVersions({
     packageKey: changedPackage?.key,
     textFilter: changedPackageVersionInputValue,
   })

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/CompareVersionsDialog/useVersionCandidate.ts
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/CompareVersionsDialog/useVersionCandidate.ts
@@ -28,7 +28,7 @@ export function useVersionCandidate(option: {
   versionContent: PackageVersionContent | null
 }): PackageVersion | undefined {
   const { packageKey, versionKey, versionContent } = option
-  const [versions] = usePackageVersions({ packageKey: packageKey, textFilter: versionKey })
+  const { versions } = usePackageVersions({ packageKey: packageKey, textFilter: versionKey })
   const isLatestRevision = versionContent?.latestRevision
 
   const versionsCandidates = useMemo(() => {

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOverviewSubPage/OperationGroupsCard/PublishOperationGroupPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOverviewSubPage/OperationGroupsCard/PublishOperationGroupPackageVersionDialog.tsx
@@ -70,7 +70,7 @@ const PublishOperationGroupPackageVersionPopup: FC<PopupProps> = memo<PopupProps
   })
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const { versions: versionsWithRevisions, isLoading: areVersionsLoading } = usePackageVersions({
+  const { versions: versionsWithRevisions, areVersionsLoading } = usePackageVersions({
     packageKey: targetPackage?.key,
     enabled: !!targetPackage,
     textFilter: versionsFilter,

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOverviewSubPage/OperationGroupsCard/PublishOperationGroupPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOverviewSubPage/OperationGroupsCard/PublishOperationGroupPackageVersionDialog.tsx
@@ -70,7 +70,7 @@ const PublishOperationGroupPackageVersionPopup: FC<PopupProps> = memo<PopupProps
   })
 
   const [versionsFilter, setVersionsFilter] = useState('')
-  const [versionsWithRevisions, areVersionsLoading] = usePackageVersions({
+  const { versions: versionsWithRevisions, isLoading: areVersionsLoading } = usePackageVersions({
     packageKey: targetPackage?.key,
     enabled: !!targetPackage,
     textFilter: versionsFilter,
@@ -79,7 +79,7 @@ const PublishOperationGroupPackageVersionPopup: FC<PopupProps> = memo<PopupProps
   const versions = useMemo(() => Object.keys(versionLabelsMap), [versionLabelsMap])
   const getVersionLabels = useCallback((version: Key) => versionLabelsMap[version] ?? [], [versionLabelsMap])
 
-  const [targetPackagePreviousVersions] = usePackageVersions({
+  const { versions: targetPackagePreviousVersions } = usePackageVersions({
     packageKey: targetPackage?.key,
     enabled: !!targetPackage,
     status: RELEASE_VERSION_STATUS,

--- a/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
@@ -56,7 +56,7 @@ export const VersionSelector: FC = memo(() => {
   const [anchor, setAnchor] = useState<HTMLElement>()
   const [activeTab, setActiveTab] = useState<VersionTab>(RELEASE_TAB)
 
-  const [versions, isLoading] = usePackageVersions({
+  const { versions, isLoading } = usePackageVersions({
     status: VERSION_STATUS_MAP[activeTab],
     textFilter: searchValue,
     sortBy: VERSION_SORT_MAP[activeTab].sortBy,

--- a/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
@@ -56,7 +56,7 @@ export const VersionSelector: FC = memo(() => {
   const [anchor, setAnchor] = useState<HTMLElement>()
   const [activeTab, setActiveTab] = useState<VersionTab>(RELEASE_TAB)
 
-  const { versions, isLoading } = usePackageVersions({
+  const { versions, areVersionsLoading } = usePackageVersions({
     status: VERSION_STATUS_MAP[activeTab],
     textFilter: searchValue,
     sortBy: VERSION_SORT_MAP[activeTab].sortBy,
@@ -87,7 +87,7 @@ export const VersionSelector: FC = memo(() => {
   const selectorContent = useMemo(() =>
     <>
       <Placeholder
-        invisible={isNotEmpty(versions) || isLoading}
+        invisible={isNotEmpty(versions) || areVersionsLoading}
         area={NAVIGATION_PLACEHOLDER_AREA}
         message={searchValue ? NO_SEARCH_RESULTS : 'No versions to display'}
       >
@@ -95,9 +95,9 @@ export const VersionSelector: FC = memo(() => {
           value={versions!}
           versionStatus={VERSION_STATUS_MAP[activeTab]}
           onClickVersion={onClickVersion}
-          isLoading={isLoading}/>
+          isLoading={areVersionsLoading}/>
       </Placeholder>
-    </>, [versions, isLoading, searchValue, activeTab, onClickVersion])
+    </>, [versions, areVersionsLoading, searchValue, activeTab, onClickVersion])
 
   return (
     <Box display="flex" alignItems="center" gap={2} overflow="hidden" data-testid="VersionSelector">

--- a/packages/shared/src/hooks/versions/usePackageVersions.ts
+++ b/packages/shared/src/hooks/versions/usePackageVersions.ts
@@ -86,8 +86,8 @@ export function usePackageVersions(options?: Partial<{
   enabled: boolean
 }>): {
   versions: PackageVersions
-  isLoading: IsLoading
-  isInitialLoading: IsInitialLoading
+  areVersionsLoading: IsLoading
+  areVersionsInitiallyLoading: IsInitialLoading
   fetchNextPage: FetchNextVersionsList
   isFetchingNextPage: IsFetchingNextPage
   hasNextPage: HasNextPage
@@ -100,8 +100,8 @@ export function usePackageVersions(options?: Partial<{
 
   const {
     data,
-    isLoading,
-    isInitialLoading,
+    isLoading: areVersionsLoading,
+    isInitialLoading: areVersionsInitiallyLoading,
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
@@ -123,8 +123,8 @@ export function usePackageVersions(options?: Partial<{
 
   return {
     versions,
-    isLoading,
-    isInitialLoading,
+    areVersionsLoading,
+    areVersionsInitiallyLoading,
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
@@ -214,11 +214,11 @@ export async function editPackageVersion(
 }
 
 export function usePackageVersionKeys(): [VersionKey[], IsLoading] {
-  const {versions: versionsData, isLoading} = usePackageVersions()
+  const {versions: versionsData, areVersionsLoading} = usePackageVersions()
   const versions = handleVersionsRevision(versionsData)
   return useMemo(
-    () => [versions.map(({ key }) => key), isLoading],
-    [isLoading, versions],
+    () => [versions.map(({ key }) => key), areVersionsLoading],
+    [areVersionsLoading, versions],
   )
 }
 


### PR DESCRIPTION
- Replace client-side version filtering with server-side search
- Fix version search performance by adding debouncing
- Add loading indicator for better UX during version search
- Rename 'versions' prop to 'version' for consistency
- Change return type of `usePackageVersions` hook from tuple to object for better readability and type safety