### PR TITLE
fix: clear package selection when workspace is reset

### DIFF
--- a/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
@@ -133,6 +133,12 @@ const CopyPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpe
 
   useEffect(() => {isCopyingStartedSuccessfully && isPublished && setOpen(false)}, [setOpen, isCopyingStartedSuccessfully, isPublished])
   useEffect(() => {reset(defaultValues)}, [defaultValues, reset])
+  useEffect(() =>{
+    if(!workspace){
+      setTargetPackage(null)
+      setValue('package', null)
+    }
+  }, [workspace, setValue])
 
   const onCopy = useCallback(async (data: CopyInfo): Promise<void> => {
     const { package: targetPackage, version, status, labels, previousVersion } = data


### PR DESCRIPTION
## Github Issue
https://github.com/Netcracker/qubership-apihub-ui/issues/51 "Copy Package" pop-up - Package should be cleared if user clears Workspace

## What
- Clear/reset package field when workspace is cleared by user.

## Why
- Previously, clearing workspace still showed old package data, which was incorrect.

## How I fixed it
- Added a condition to reset/clear the package name in the state when the workspace is cleared.
- Ensured that both workspace and package fields are properly reset in sync.
- Also tested the clearing action to ensure no residual data remains.

## How to Test
1. Select any workspace and select a package.
2. Now, clear the workspace.
3. Expected: The package field should immediately be reset (empty).
4. No console errors should appear.
5. Try selecting again to ensure fresh data is loaded.

✅ Tested locally and functionality works as expected. 
✅ UI behavior is smooth without any errors.