### PR TITLE
updated block name from Target Package to Target Dashboard

### DIFF
--- a/packages/shared/src/components/VersionDialogForm.tsx
+++ b/packages/shared/src/components/VersionDialogForm.tsx
@@ -418,7 +418,7 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
 
         {!hideCopyPackageFields && (
           <>
-            <Typography sx={{ mb: 1 }} variant="body2">Target Package</Typography>
+            <Typography sx={{ mb: 1 }} variant="body2">Target Dashboard</Typography>
 
             <Controller
               name="workspace"


### PR DESCRIPTION
## Github Issue
#50 "Copy Dashboard" pop-up - "Target Package" instead of "Target Dashboard"

## What
- In Popup it should be **Target Dashboard** instead of **Target Package**

## How I fixed it
- Renamed Package to Dashboard

## How to test it
- Open Dashboard
- Click [Copy] and check occured pop-up.