### PR TITLE
fix: retained existing REST grouping prefix in edit popup

### DIFF
--- a/packages/portal/src/routes/EventBusProvider.tsx
+++ b/packages/portal/src/routes/EventBusProvider.tsx
@@ -161,6 +161,7 @@ export type OperationsMovementDetails =
 
 export type ShowEditPackagePrefixDetail = {
   packageKey?: string
+  existingPrefix?:string
 }
 
 type EventBus = {

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/SpecificConfigurationPackageSettingsTab/EditGrouppingPrefixDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/SpecificConfigurationPackageSettingsTab/EditGrouppingPrefixDialog.tsx
@@ -38,15 +38,19 @@ export const EditGrouppingPrefixDialog: FC = memo(() => {
 })
 
 const EditPrefixDialogPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpen, detail }) => {
-  const { packageKey } = detail as ShowEditPackagePrefixDetail
+  const { packageKey, existingPrefix = '' } = detail as ShowEditPackagePrefixDetail &  { existingPrefix?: string }
   const [updatePackage, isUpdateLoading, isSuccess] = useUpdatePackage()
   const [recalculatePackageVersionGroups] = useRecalculatePackageVersionGroups()
   useEffect(() => {isSuccess && setOpen(false)}, [isSuccess, setOpen])
 
+  useEffect(() => {
+    if (isSuccess) setOpen(false)
+  }, [isSuccess, setOpen])
+
   const defaultValues = useMemo(() => ({
-    restGroupingPrefix: '',
+    restGroupingPrefix: existingPrefix,
     recalculate: false,
-  }), [])
+  }), [existingPrefix])
 
   const { handleSubmit, control, formState: { errors }, watch } = useForm<FormData>({ defaultValues })
   const { recalculate } = watch()

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/SpecificConfigurationPackageSettingsTab/EditGrouppingPrefixDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/SpecificConfigurationPackageSettingsTab/EditGrouppingPrefixDialog.tsx
@@ -43,10 +43,6 @@ const EditPrefixDialogPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpen,
   const [recalculatePackageVersionGroups] = useRecalculatePackageVersionGroups()
   useEffect(() => {isSuccess && setOpen(false)}, [isSuccess, setOpen])
 
-  useEffect(() => {
-    if (isSuccess) setOpen(false)
-  }, [isSuccess, setOpen])
-
   const defaultValues = useMemo(() => ({
     restGroupingPrefix: existingPrefix,
     recalculate: false,

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/SpecificConfigurationPackageSettingsTab/SpecificConfigurationPackageSettingsTab.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/SpecificConfigurationPackageSettingsTab/SpecificConfigurationPackageSettingsTab.tsx
@@ -44,6 +44,7 @@ export const SpecificConfigurationPackageSettingsTab: FC<PackageSettingsTabProps
   const onEditPackagePrefix = useCallback(() => {
     showEditPackagePrefixDialog({
       packageKey: packageObject?.key,
+      existingPrefix: packageObject?.restGroupingPrefix ?? '',
     })
   }, [packageObject, showEditPackagePrefixDialog])
 


### PR DESCRIPTION
## Github Issue
https://github.com/Netcracker/qubership-apihub-ui/issues/55  [FE] Value for REST Grouping Prefix is missed in Edit pop-up

## What
Fixed issue where the REST Grouping Prefix field did not retain user input after closing and reopening the popup.

## How I fixed it
- Added 'existingPrefix' to the popup details object
- Used this value to pre-fill the field in the form via react-hook-form's defaultValues
- Ensured the user can update the value correctly and persist changes

## How to test It
- Navigate to the package from precondition.
- Click Manage Package button.
- Navigate to API Specific Configuration tab -> $REST Path Prefix for Grouping by Version=/api/{group}/ (value exists).
- Click Edit button -> Pop-up opened.


