### PR TITLE
refactor: align LabelsAutocomplete style

### DIFF
--- a/packages/shared/src/components/LabelsAutocomplete.tsx
+++ b/packages/shared/src/components/LabelsAutocomplete.tsx
@@ -1,23 +1,7 @@
-/**
- * Copyright 2024-2025 NetCracker Technology Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import type { FC, SyntheticEvent } from 'react'
-import { memo } from 'react'
+import React, { memo } from 'react'
 import type { AutocompleteValue } from '@mui/material'
-import { Autocomplete, TextField } from '@mui/material'
+import { Autocomplete, Chip, TextField } from '@mui/material'
 
 export type LabelsAutocompleteProps = {
   onChange: (event: SyntheticEvent, value: AutocompleteValue<string, true, false, true>) => void
@@ -27,7 +11,7 @@ export type LabelsAutocompleteProps = {
 export const LabelsAutocomplete: FC<LabelsAutocompleteProps> = memo<LabelsAutocompleteProps>(({ onChange, value }) => {
   return (
     <Autocomplete
-      sx={AUTOCOMPLETE_STYLE}
+      sx={autocompleteSx}
       open={false}
       value={value}
       options={[]}
@@ -36,23 +20,35 @@ export const LabelsAutocomplete: FC<LabelsAutocompleteProps> = memo<LabelsAutoco
       freeSolo
       renderInput={(params) => (
         <TextField
-          multiline
-          maxRows={Infinity}
           autoComplete="on"
           {...params}
           label="Labels"
         />
       )}
+      renderTags={(tagValue, getTagProps): React.ReactElement[] =>
+        tagValue.map((value, index): React.ReactElement => {
+          const { ...tagProps } = getTagProps({ index })
+          return (
+            <Chip
+              {...tagProps}
+              key={value}
+              label={value}
+              size="small"
+            />
+          )
+        })
+      }
       onChange={onChange}
       data-testid="LabelsAutocomplete"
     />
   )
 })
 
-const AUTOCOMPLETE_STYLE = {
+const autocompleteSx = {
   '& .MuiAutocomplete-tag': {
-    height: '24px',
-    marginTop: '4px',
+    my: 0.5,
   },
 }
+
+LabelsAutocomplete.displayName = 'LabelsAutocomplete'
 


### PR DESCRIPTION
Updates the `LabelsAutocomplete` component to render tags using the Material UI `Chip` component, similar to the `LabellessAutocomplete` component.

- Adjusted styles for tags.
- Removed multiline and maxRows props from TextField as they're unnecessary (it fixes bug with empty value)
- Added `displayName` for better debugging.

<img width="305" alt="before" src="https://github.com/user-attachments/assets/c8edab5c-8e0c-4c25-b282-f48a55524788" />
<img width="300" alt="after" src="https://github.com/user-attachments/assets/a1acf131-6963-44ed-b5c5-b2c609a9fc29" />
