### PR TITLE
feat: more general definition of changes requiring attention in tooltip

### DIFF
--- a/packages/shared/src/entities/change-severities.ts
+++ b/packages/shared/src/entities/change-severities.ts
@@ -80,10 +80,7 @@ export const CHANGE_SEVERITY_TOOLTIP_TITLE_MAP: Record<ChangeSeverity, string> =
 
 export const CHANGE_SEVERITY_DESCRIPTION_MAP: Record<ChangeSeverity, { text: string; options?: string[] }> = {
   [breaking]: { text: 'Breaking change is a change that breaks backward compatibility with the previous version of API. For example, deleting an operation, adding a required parameter or changing type of a parameter are breaking changes.' },
-  [risky]: {
-    text: 'A change requiring attention is a change that breaks backward compatibility according to the rules:',
-    options: ['operation was annotated as deprecated in at least two previous consecutive releases and then it was deleted', 'operation is marked as no-BWC'],
-  },
+  [risky]: { text: 'A change requiring attention is a change that potentially may break backward compatibility with the previous version of API, depending on the particular implementation of a client code. This category also includes breaking changes in operations annotated as no-BWC.'},
   [deprecated]: { text: 'Deprecating change is a change that annotates an operation, parameter or schema as deprecated. Removing a "deprecated" annotation is also considered a deprecating change.' },
   [nonBreaking]: { text: 'Non-breaking change is change that does not break backward compatibility with the previous version of API. For example, adding new operation or optional parameter is non-breaking change.' },
   [unclassified]: { text: 'An unclassified change is a change that cannot be classified as any of the other types.' },


### PR DESCRIPTION
After implementing https://github.com/Netcracker/qubership-apihub-api-diff/pull/8 definition of changes that requires attention became more broad, this PR generalizes the corresponding description in tooltip.