### PR TITLE
fix: title overflow in detailed view

### DIFF
--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
@@ -38,7 +38,6 @@ import { normalizeOpenApiDocument } from '@netcracker/qubership-apihub-ui-shared
 import { YAML_FILE_VIEW_MODE } from '@netcracker/qubership-apihub-ui-shared/entities/file-format-view'
 import type { ApiType } from '@netcracker/qubership-apihub-ui-shared/entities/api-types'
 import { removeComponents } from '@netcracker/qubership-apihub-api-processor'
-import { OverflowTooltip } from '@netcracker/qubership-apihub-ui-shared/components/OverflowTooltip'
 
 export type OperationPreviewProps = {
   apiType: ApiType
@@ -97,47 +96,31 @@ export const OperationPreview: FC<OperationPreviewProps> = memo<OperationPreview
             <ToolbarTitle
               value={
                 <Box
+                  component="span"
                   sx={{
-                    maxWidth: '60vw',           // restrict max width of title
+                    maxWidth: '60vw',         // restrict max width
+                    display: 'inline-block',
                     overflow: 'hidden',
                     whiteSpace: 'nowrap',
                     textOverflow: 'ellipsis',
+                    width: '100%',
                   }}
                 >
-                  <Box>
-                    <Box
-                      component="span"
-                      sx={{
-                        display: 'inline-block',
-                        overflow: 'hidden',
-                        whiteSpace: 'nowrap',
-                        textOverflow: 'ellipsis',
-                        width: '100%',
-                      }}
-                    >
-                      <OperationTitleWithMeta
-                        onlyTitle
-                        operation={changedOperation}
-                        badgeText={changedOperation.deprecated ? 'Deprecated' : undefined}
-                      />
-                    </Box>
-                  </Box>
+                  <OperationTitleWithMeta
+                    onlyTitle
+                    operation={changedOperation}
+                    badgeText={changedOperation.deprecated ? 'Deprecated' : undefined}
+                  />
                 </Box>
               }
             />
           }
-          action={<OperationViewModeSelector modes={OPERATION_PREVIEW_VIEW_MODES} />}
+          action={< OperationViewModeSelector modes={OPERATION_PREVIEW_VIEW_MODES} />}
         />
-        <Divider orientation="horizontal" variant="fullWidth" />
-      </Box>
+        < Divider orientation="horizontal" variant="fullWidth" />
+      </Box >
 
-      <Box
-        sx={{
-          overflowX: 'hidden', // restrict sideways scroll
-          width: '100%',       // occupy full parent width
-          minWidth: 0,         // allow child truncation instead of expanding
-        }}
-      >
+      <Box>
         {isDocViewMode && (
           <OperationView
             apiType={apiType}
@@ -158,6 +141,6 @@ export const OperationPreview: FC<OperationPreviewProps> = memo<OperationPreview
           />
         )}
       </Box>
-    </Box>
+    </Box >
   )
 })

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
@@ -104,7 +104,7 @@ export const OperationPreview: FC<OperationPreviewProps> = memo<OperationPreview
                     textOverflow: 'ellipsis',
                   }}
                 >
-                  <OverflowTooltip title={changedOperation?.summary ?? ''}>
+                  <Box>
                     <Box
                       component="span"
                       sx={{
@@ -121,7 +121,7 @@ export const OperationPreview: FC<OperationPreviewProps> = memo<OperationPreview
                         badgeText={changedOperation.deprecated ? 'Deprecated' : undefined}
                       />
                     </Box>
-                  </OverflowTooltip>
+                  </Box>
                 </Box>
               }
             />

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
@@ -95,23 +95,11 @@ export const OperationPreview: FC<OperationPreviewProps> = memo<OperationPreview
           header={
             <ToolbarTitle
               value={
-                <Box
-                  component="span"
-                  sx={{
-                    maxWidth: '60vw',         // restrict max width
-                    display: 'inline-block',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                    width: '100%',
-                  }}
-                >
-                  <OperationTitleWithMeta
-                    onlyTitle
-                    operation={changedOperation}
-                    badgeText={changedOperation.deprecated ? 'Deprecated' : undefined}
-                  />
-                </Box>
+                <OperationTitleWithMeta
+                  onlyTitle
+                  operation={changedOperation}
+                  badgeText={changedOperation.deprecated ? 'Deprecated' : undefined}
+                />
               }
             />
           }

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOperationsSubPage/OperationPreview.tsx
@@ -38,6 +38,7 @@ import { normalizeOpenApiDocument } from '@netcracker/qubership-apihub-ui-shared
 import { YAML_FILE_VIEW_MODE } from '@netcracker/qubership-apihub-ui-shared/entities/file-format-view'
 import type { ApiType } from '@netcracker/qubership-apihub-ui-shared/entities/api-types'
 import { removeComponents } from '@netcracker/qubership-apihub-api-processor'
+import { OverflowTooltip } from '@netcracker/qubership-apihub-ui-shared/components/OverflowTooltip'
 
 export type OperationPreviewProps = {
   apiType: ApiType
@@ -74,7 +75,7 @@ export const OperationPreview: FC<OperationPreviewProps> = memo<OperationPreview
 
   if (isLoading) {
     return (
-      <LoadingIndicator/>
+      <LoadingIndicator />
     )
   } else if (!changedOperation?.operationKey) {
     return (
@@ -95,20 +96,48 @@ export const OperationPreview: FC<OperationPreviewProps> = memo<OperationPreview
           header={
             <ToolbarTitle
               value={
-                <OperationTitleWithMeta
-                  onlyTitle
-                  operation={changedOperation}
-                  badgeText={changedOperation.deprecated ? 'Deprecated' : undefined}
-                />
+                <Box
+                  sx={{
+                    maxWidth: '60vw',           // restrict max width of title
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  <OverflowTooltip title={changedOperation?.summary ?? ''}>
+                    <Box
+                      component="span"
+                      sx={{
+                        display: 'inline-block',
+                        overflow: 'hidden',
+                        whiteSpace: 'nowrap',
+                        textOverflow: 'ellipsis',
+                        width: '100%',
+                      }}
+                    >
+                      <OperationTitleWithMeta
+                        onlyTitle
+                        operation={changedOperation}
+                        badgeText={changedOperation.deprecated ? 'Deprecated' : undefined}
+                      />
+                    </Box>
+                  </OverflowTooltip>
+                </Box>
               }
             />
           }
-          action={<OperationViewModeSelector modes={OPERATION_PREVIEW_VIEW_MODES}/>}
+          action={<OperationViewModeSelector modes={OPERATION_PREVIEW_VIEW_MODES} />}
         />
-        <Divider orientation="horizontal" variant="fullWidth"/>
+        <Divider orientation="horizontal" variant="fullWidth" />
       </Box>
 
-      <Box>
+      <Box
+        sx={{
+          overflowX: 'hidden', // restrict sideways scroll
+          width: '100%',       // occupy full parent width
+          minWidth: 0,         // allow child truncation instead of expanding
+        }}
+      >
         {isDocViewMode && (
           <OperationView
             apiType={apiType}

--- a/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
+++ b/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
@@ -16,7 +16,7 @@
 
 import type { FC } from 'react'
 import React, { memo, useMemo } from 'react'
-import { Box, Link } from '@mui/material'
+import { Box, Link, Typography } from '@mui/material'
 import { NavLink } from 'react-router-dom'
 import type { Path } from '@remix-run/router'
 import type { Operation } from '../../entities/operations'
@@ -63,31 +63,21 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
   }, [operation])
 
   const titleNode = link
-    ? (
-      <TextWithOverflowTooltip tooltipText={title} variant="subtitle1">
-        <Link
-          component={NavLink}
-          to={link}
-          target={openLinkInNewTab ? '_blank' : '_self'}
-          onClick={(event) => {
-            event.stopPropagation()
-            onLinkClick?.()
-          }}
-        >
-          {title}
-        </Link>
-      </TextWithOverflowTooltip>
-    )
-    : (
-      <TextWithOverflowTooltip tooltipText={title} variant="inherit"
-        sx={{
-          maxWidth: '60vw',
-          overflow: 'hidden',
+      ? <Typography noWrap variant="subtitle1">
+      <Link
+        component={NavLink}
+        to={link}
+        target={openLinkInNewTab ? '_blank' : '_self'}
+        onClick={(event) => {
+          event.stopPropagation()
+          onLinkClick?.()
         }}
       >
         {title}
-      </TextWithOverflowTooltip>
-    )
+       </Link>
+    </Typography>
+    : <Typography noWrap variant="inherit">{title}</Typography>
+    
 
   return (
     <Box display="flex" flexDirection="column" width="100%">
@@ -96,11 +86,6 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
         alignItems="center"
         gap={1}
         data-testid="OperationTitle"
-        sx={{
-          maxWidth: '60vw',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-        }}
       >
         {titleNode}
 

--- a/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
+++ b/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
@@ -52,32 +52,50 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
         subtitle: operation.path,
         type: operation.method,
       }
-    }
-    if (isGraphQlOperation(operation)) {
+    } else if (isGraphQlOperation(operation)) {
       return {
         title: operation.title,
         subtitle: operation.method,
         type: operation.type,
       }
+    } else {
+      throw new Error('Operation must be either a REST or GraphQL operation')
     }
-    throw new Error('Operation must be either a REST or GraphQL operation')
   }, [operation])
 
   const titleNode = link
-    ? <Typography noWrap variant="subtitle1">
-      <Link
-        component={NavLink}
-        to={link}
-        target={openLinkInNewTab ? '_blank' : '_self'}
-        onClick={(event) => {
-          event.stopPropagation()
-          onLinkClick?.()
+    ? (<Box
+      sx={{
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+      }}
+    >
+      <Typography noWrap variant="subtitle1">
+        <Link
+          component={NavLink}
+          to={link}
+          target={openLinkInNewTab ? '_blank' : '_self'}
+          onClick={(event) => {
+            event.stopPropagation()
+            onLinkClick?.()
+          }}
+        >
+          {title}
+        </Link>
+      </Typography>
+    </Box>
+    )
+    : (
+      <Box
+        sx={{
+          maxWidth: '90%',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
         }}
       >
-        {title}
-      </Link>
-    </Typography>
-    : <Typography noWrap variant="inherit">{title}</Typography>
+        <Typography noWrap variant="inherit">{title}</Typography>
+      </Box>
+    )
 
   return (
     <Box display="flex" flexDirection="column" width="100%">

--- a/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
+++ b/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
@@ -16,7 +16,7 @@
 
 import type { FC } from 'react'
 import React, { memo, useMemo } from 'react'
-import { Box, Link, Typography } from '@mui/material'
+import { Box, Link } from '@mui/material'
 import { NavLink } from 'react-router-dom'
 import type { Path } from '@remix-run/router'
 import type { Operation } from '../../entities/operations'
@@ -64,13 +64,8 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
   }, [operation])
 
   const titleNode = link
-    ? (<Box
-      sx={{
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-      }}
-    >
-      <Typography noWrap variant="subtitle1">
+    ? (
+      <TextWithOverflowTooltip tooltipText={title} variant="subtitle1">
         <Link
           component={NavLink}
           to={link}
@@ -82,19 +77,17 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
         >
           {title}
         </Link>
-      </Typography>
-    </Box>
+      </TextWithOverflowTooltip>
     )
     : (
-      <Box
-        sx={{
-          maxWidth: '90%',
-          whiteSpace: 'nowrap',
+      <TextWithOverflowTooltip tooltipText={title} variant="inherit"
+       sx={{
+          maxWidth: '60vw',
           overflow: 'hidden',
         }}
       >
-        <Typography noWrap variant="inherit">{title}</Typography>
-      </Box>
+        {title}
+      </TextWithOverflowTooltip>
     )
 
   return (
@@ -104,9 +97,25 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
         alignItems="center"
         gap={1}
         data-testid="OperationTitle"
+        sx={{
+          maxWidth: '60vw',
+          overflow: 'hidden',
+        }}
       >
         <OverflowTooltip title={title}>
-          {titleNode}
+          {/* {titleNode} */}
+           <Box
+            component="span"
+            sx={{
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+              display: 'inline-block',
+              width: '100%',
+            }}
+          >
+            {titleNode}
+          </Box>
         </OverflowTooltip>
 
         {badgeText &&

--- a/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
+++ b/packages/shared/src/components/Operations/OperationTitleWithMeta.tsx
@@ -21,7 +21,6 @@ import { NavLink } from 'react-router-dom'
 import type { Path } from '@remix-run/router'
 import type { Operation } from '../../entities/operations'
 import { isGraphQlOperation, isRestOperation } from '../../entities/operations'
-import { OverflowTooltip } from '../OverflowTooltip'
 import { CustomChip } from '../CustomChip'
 import { TextWithOverflowTooltip } from '../TextWithOverflowTooltip'
 
@@ -81,7 +80,7 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
     )
     : (
       <TextWithOverflowTooltip tooltipText={title} variant="inherit"
-       sx={{
+        sx={{
           maxWidth: '60vw',
           overflow: 'hidden',
         }}
@@ -100,31 +99,18 @@ export const OperationTitleWithMeta: FC<OperationTitleWithMetaProps> = memo<Oper
         sx={{
           maxWidth: '60vw',
           overflow: 'hidden',
+          whiteSpace: 'nowrap',
         }}
       >
-        <OverflowTooltip title={title}>
-          {/* {titleNode} */}
-           <Box
-            component="span"
-            sx={{
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-              display: 'inline-block',
-              width: '100%',
-            }}
-          >
-            {titleNode}
-          </Box>
-        </OverflowTooltip>
+        {titleNode}
 
-        {badgeText &&
+        {badgeText && (
           <CustomChip
             value={badgeText.toLowerCase()}
             label={badgeText}
             isExtraSmall
           />
-        }
+        )}
       </Box>
       {!onlyTitle && (
         <Box display="flex" alignItems="center" gap={1} data-testid="OperationPath">

--- a/packages/shared/src/components/Operations/OperationWithMetaClickableList.tsx
+++ b/packages/shared/src/components/Operations/OperationWithMetaClickableList.tsx
@@ -119,8 +119,8 @@ export const OperationWithMetaClickableList: FC<OperationWithMetaClickableListPr
           <Box overflow="auto" height="inherit">
             {operationsList}
 
-            {isLoading && <ListSkeleton/>}
-            {hasNextPage && <Box ref={ref}><Skeleton variant="rectangular" width="100%"/></Box>}
+            {isLoading && <ListSkeleton />}
+            {hasNextPage && <Box ref={ref}><Skeleton variant="rectangular" width="100%" /></Box>}
           </Box>
         </Placeholder>
       </ListBox>
@@ -158,7 +158,7 @@ const ListSkeleton: FC = memo(() => {
     <Box>
       {[...Array(5)].map((_, index) => (
         <Box key={index} mb={2}>
-          <Skeleton variant="rectangular" height={20} width="100%"/>
+          <Skeleton variant="rectangular" height={20} width="100%" />
         </Box>
       ))}
     </Box>
@@ -175,32 +175,32 @@ type OperationItemButtonProps = {
 }
 
 const OperationItemButton: FC<OperationItemButtonProps> = memo<OperationItemButtonProps>(({
-    title,
-    operation,
-    expandable,
-    onClick,
-    SubComponent,
-    selected,
-  }) => {
-    const [expanded, setExpanded] = useState<boolean>(false)
+  title,
+  operation,
+  expandable,
+  onClick,
+  SubComponent,
+  selected,
+}) => {
+  const [expanded, setExpanded] = useState<boolean>(false)
 
-    return (
-      <>
-        <CustomListItemButton<OperationData>
-          keyProp={operation.operationKey}
-          data={operation}
-          itemComponent={<ExpandableItem showToggler={expandable} onToggle={setExpanded}>{title}</ExpandableItem>}
-          onClick={onClick}
-          size={LIST_ITEM_SIZE_BIG}
-          isSelected={selected}
-          testId="Cell-endpoints"
-        />
-        <Divider orientation="horizontal" variant="fullWidth"/>
+  return (
+    <>
+      <CustomListItemButton<OperationData>
+        keyProp={operation.operationKey}
+        data={operation}
+        itemComponent={<ExpandableItem showToggler={expandable} onToggle={setExpanded}>{title}</ExpandableItem>}
+        onClick={onClick}
+        size={LIST_ITEM_SIZE_BIG}
+        isSelected={selected}
+        testId="Cell-endpoints"
+      />
+      <Divider orientation="horizontal" variant="fullWidth" />
 
-        {expanded && SubComponent && (
-          <SubComponent operation={operation}/>
-        )}
-      </>
-    )
-  },
+      {expanded && SubComponent && (
+        <SubComponent operation={operation} />
+      )}
+    </>
+  )
+},
 )

--- a/packages/shared/src/components/Toolbar.tsx
+++ b/packages/shared/src/components/Toolbar.tsx
@@ -43,17 +43,25 @@ export const Toolbar: FC<ToolbarProps> = memo<ToolbarProps>(({
         subheader={
           <Box
             display="flex"
-            maxWidth="55vw"
-            gap={1}
-            alignItems="baseline"
-            height={28}
+            alignItems="center"
+            gap={2}
+            maxWidth="100%"
+            sx={{ overflow: 'hidden' }}
           >
             {header}
           </Box>
         }
         subheaderTypographyProps={{ variant: 'h5', color: '#000000' }}
         action={
-          <Box display="flex" gap={1}>
+          <Box display="flex" gap={1}
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
             {action}
           </Box>
         }

--- a/packages/shared/src/components/Toolbar.tsx
+++ b/packages/shared/src/components/Toolbar.tsx
@@ -40,31 +40,9 @@ export const Toolbar: FC<ToolbarProps> = memo<ToolbarProps>(({
       <CardHeader
         sx={{ height: TOOLBAR_HEIGHT[breadcrumbs ? LARGE_TOOLBAR_SIZE : size], px: 4 }}
         title={breadcrumbs}
-        subheader={
-          <Box
-            display="flex"
-            alignItems="center"
-            gap={2}
-            maxWidth="100%"
-            sx={{ overflow: 'hidden' }}
-          >
-            {header}
-          </Box>
-        }
+        subheader={header}
         subheaderTypographyProps={{ variant: 'h5', color: '#000000' }}
-        action={
-          <Box display="flex" gap={1}
-            sx={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              flex: 1,
-              minWidth: 0,
-            }}
-          >
-            {action}
-          </Box>
-        }
+        action={action}
         data-testid={testId}
       />
     </Card>


### PR DESCRIPTION
## Github Issue
https://github.com/Netcracker/qubership-apihub/issues/50 [Portal] Detailed view - Operation with long name hides "Doc/Simple/Raw" view selector

## What
- In detailed view, long API operation titles push and hide the Doc/Simple/Raw view selector.

## How I solved
- Used a flex layout with appropriate code fixes for the title section.
- Allow the title to shrink only when necessary.