### PR TITLE
feat(ci): add pr-assigner.yml workflow which uses CODEOWNERS instead of configuration

### DIFF
--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -1,0 +1,35 @@
+name: PR Auto-Assignment
+run-name: "Assigning reviewers for PR #${{ github.event.pull_request.number }}"
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pr-auto-assign:
+    name: "Auto-assign Reviewers to PR #${{ github.event.pull_request.number }}"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: "Check if PR is from a fork"
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+            echo "⚠️ Pull request is from a fork — skipping assignee assignment (no write permissions)."
+            exit 0
+          fi
+
+      - name: "Checkout Repository"
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: "Assign Reviewers"
+        uses: netcracker/qubership-workflow-hub/actions/pr-assigner@b575bad3a0959c4e883bc34f9d055ff07fde2dbd #2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Related issue: https://github.com/Netcracker/qubership-workflow-hub/issues/458