### PR TITLE
feat: start builds with relaxed api-processor version validation if migration is in progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mui/private-theming": "5.11.9",
     "@netcracker/qubership-apihub-api-diff": "dev",
     "@netcracker/qubership-apihub-api-doc-viewer": "dev",
-    "@netcracker/qubership-apihub-api-processor": "dev",
+    "@netcracker/qubership-apihub-api-processor": "feature-migration-mode",
     "@netcracker/qubership-apihub-api-unifier": "dev",
     "@netcracker/qubership-apihub-api-visitor": "dev",
     "@netcracker/qubership-apihub-apispec-view": "dev",

--- a/packages/agents/src/routes/root/NamespacePage/ServicesPage/ServicesPageBody/package-version-builder-worker.ts
+++ b/packages/agents/src/routes/root/NamespacePage/ServicesPage/ServicesPageBody/package-version-builder-worker.ts
@@ -20,6 +20,7 @@ import type { PublishDetails } from '@apihub/entities/publish-details'
 import { setPublicationDetails } from '@apihub/entities/publish-details'
 import type { PublishStatus } from '@apihub/entities/statuses'
 import { COMPLETE_PUBLISH_STATUS, ERROR_PUBLISH_STATUS } from '@apihub/entities/statuses'
+import type { VersionValidationLevel } from '@netcracker/qubership-apihub-api-processor'
 import { BUILD_TYPE, PackageVersionBuilder } from '@netcracker/qubership-apihub-api-processor'
 import {
   packageVersionResolver,
@@ -30,6 +31,7 @@ import {
   versionReferencesResolver,
 } from '@netcracker/qubership-apihub-ui-shared/utils/builder-resolvers'
 import { NONE_PUBLISH_STATUS, RUNNING_PUBLISH_STATUS } from '@netcracker/qubership-apihub-ui-shared/utils/packages-builder'
+import { getSystemInfo } from '@netcracker/qubership-apihub-ui-shared/utils/system-info'
 import { expose } from 'comlink'
 import { getSpecBlob } from '../../useSpecRaw'
 
@@ -47,6 +49,15 @@ export type PublishServiceOptions = {
 
 export type PackageVersionBuilderWorker = {
   publishService: (options: PublishServiceOptions) => Promise<PublishDetails>
+}
+
+async function getValidationLevel(): Promise<VersionValidationLevel> {
+  try {
+    const info = await getSystemInfo()
+    return info.migrationInProgress ? 'major' : 'strict'
+  } catch {
+    return 'strict'
+  }
 }
 
 const worker: PackageVersionBuilderWorker = {
@@ -88,7 +99,8 @@ const worker: PackageVersionBuilderWorker = {
     let message
 
     try {
-      await builder.run()
+      const level = await getValidationLevel()
+      await builder.run({ apiProcessorVersionValidationLevel: level })
       const data = await builder.createVersionPackage({ type: 'blob' })
       stopSendingRunningStatus()
 

--- a/packages/agents/src/routes/root/NamespacePage/ServicesPage/ServicesPageBody/package-version-builder-worker.ts
+++ b/packages/agents/src/routes/root/NamespacePage/ServicesPage/ServicesPageBody/package-version-builder-worker.ts
@@ -21,7 +21,7 @@ import { setPublicationDetails } from '@apihub/entities/publish-details'
 import type { PublishStatus } from '@apihub/entities/statuses'
 import { COMPLETE_PUBLISH_STATUS, ERROR_PUBLISH_STATUS } from '@apihub/entities/statuses'
 import type { VersionValidationLevel } from '@netcracker/qubership-apihub-api-processor'
-import { BUILD_TYPE, PackageVersionBuilder } from '@netcracker/qubership-apihub-api-processor'
+import { BUILD_TYPE, PackageVersionBuilder, VERSION_VALIDATION_LEVEL } from '@netcracker/qubership-apihub-api-processor'
 import {
   packageVersionResolver,
   rawDocumentResolver,
@@ -54,9 +54,9 @@ export type PackageVersionBuilderWorker = {
 async function getValidationLevel(): Promise<VersionValidationLevel> {
   try {
     const info = await getSystemInfo()
-    return info.migrationInProgress ? 'major' : 'strict'
+    return info.migrationInProgress ? VERSION_VALIDATION_LEVEL.MAJOR : VERSION_VALIDATION_LEVEL.STRICT
   } catch {
-    return 'strict'
+    return VERSION_VALIDATION_LEVEL.STRICT
   }
 }
 

--- a/packages/portal/src/routes/root/PortalPage/package-version-builder-worker.ts
+++ b/packages/portal/src/routes/root/PortalPage/package-version-builder-worker.ts
@@ -15,7 +15,7 @@
  */
 
 import type { BuilderResolvers, FileId, FileSourceMap, VersionValidationLevel, VersionsComparison } from '@netcracker/qubership-apihub-api-processor'
-import { BUILD_TYPE, PackageVersionBuilder, VERSION_STATUS } from '@netcracker/qubership-apihub-api-processor'
+import { BUILD_TYPE, PackageVersionBuilder, VERSION_STATUS, VERSION_VALIDATION_LEVEL } from '@netcracker/qubership-apihub-api-processor'
 import {
   packageVersionResolver,
   rawDocumentResolver,
@@ -67,9 +67,9 @@ export type PackageVersionBuilderWorker = {
 async function getValidationLevel(): Promise<VersionValidationLevel> {
   try {
     const info = await getSystemInfo()
-    return info.migrationInProgress ? 'major' : 'strict'
+    return info.migrationInProgress ? VERSION_VALIDATION_LEVEL.MAJOR : VERSION_VALIDATION_LEVEL.STRICT
   } catch {
-    return 'strict'
+    return VERSION_VALIDATION_LEVEL.STRICT
   }
 }
 

--- a/packages/portal/src/routes/root/PortalPage/package-version-builder-worker.ts
+++ b/packages/portal/src/routes/root/PortalPage/package-version-builder-worker.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { BuilderResolvers, FileId, FileSourceMap, VersionsComparison } from '@netcracker/qubership-apihub-api-processor'
+import type { BuilderResolvers, FileId, FileSourceMap, VersionValidationLevel, VersionsComparison } from '@netcracker/qubership-apihub-api-processor'
 import { BUILD_TYPE, PackageVersionBuilder, VERSION_STATUS } from '@netcracker/qubership-apihub-api-processor'
 import {
   packageVersionResolver,
@@ -64,7 +64,7 @@ export type PackageVersionBuilderWorker = {
   init: (lastIdentityProviderId: string | null) => Promise<void>
 }
 
-async function getValidationLevel(): Promise<'major' | 'strict'> {
+async function getValidationLevel(): Promise<VersionValidationLevel> {
   try {
     const info = await getSystemInfo()
     return info.migrationInProgress ? 'major' : 'strict'
@@ -126,7 +126,8 @@ const worker: PackageVersionBuilderWorker = {
       },
     )
 
-    await builder.run()
+    const groupLevel = await getValidationLevel()
+    await builder.run({ apiProcessorVersionValidationLevel: groupLevel })
 
     return [builder.buildResult.comparisons, await builder.createVersionPackage({ type: 'blob' })]
   },

--- a/packages/portal/src/routes/root/PortalPage/package-version-builder-worker.ts
+++ b/packages/portal/src/routes/root/PortalPage/package-version-builder-worker.ts
@@ -40,6 +40,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { BuilderOptions } from './package-version-builder'
 import type { PublishOptions } from './usePublishPackageVersion'
 import { systemConfiguration } from '@netcracker/qubership-apihub-ui-shared/hooks/authorization/useSystemConfiguration'
+import { getSystemInfo } from '@netcracker/qubership-apihub-ui-shared/utils/system-info'
 
 /*
 For using worker in proxy mode you need to change common apihub-shared import
@@ -61,6 +62,15 @@ export type PackageVersionBuilderWorker = {
   buildGroupChangelogPackage: (options: BuilderOptions) => Promise<[VersionsComparison[], Blob]>
   publishPackage: (options: PublishOptions) => Promise<PublishDetails>
   init: (lastIdentityProviderId: string | null) => Promise<void>
+}
+
+async function getValidationLevel(): Promise<'major' | 'strict'> {
+  try {
+    const info = await getSystemInfo()
+    return info.migrationInProgress ? 'major' : 'strict'
+  } catch {
+    return 'strict'
+  }
 }
 
 async function createCommonResolvers(): Promise<BuilderResolvers> {
@@ -96,7 +106,8 @@ const worker: PackageVersionBuilderWorker = {
       },
     )
 
-    await builder.run()
+    const level = await getValidationLevel()
+    await builder.run({ apiProcessorVersionValidationLevel: level })
 
     return [builder.buildResult.comparisons, await builder.createVersionPackage({ type: 'blob' })]
   },
@@ -157,7 +168,8 @@ const worker: PackageVersionBuilderWorker = {
     let message
 
     try {
-      await builder.run()
+      const level = await getValidationLevel()
+      await builder.run({ apiProcessorVersionValidationLevel: level })
       const data = await builder?.createVersionPackage({ type: 'blob' })
       stopSendingRunningStatus()
 


### PR DESCRIPTION
 ## Summary
                                                                                                                                                                                                                                                                                                 
  - When a data migration is in progress, the UI now passes `apiProcessorVersionValidationLevel: 'major'` to the api-processor builder, allowing users to continue publishing packages even if the previous version was built with a different minor/patch api-processor version
  - When no migration is running (or if the system info endpoint is unavailable), the default `strict` validation is used
  - Applied to all three builder entry points: changelog build, prefix group changelog build, and publish (portal and agents)
  
  ## Changes

  - **`packages/portal/.../package-version-builder-worker.ts`**: Added `getValidationLevel()` that queries `/api/v1/system/info` for `migrationInProgress` and returns `'major'` or `'strict'`. Passed the level to all `builder.run()` calls (changelog, prefix group changelog, publish). Used
  `VersionValidationLevel` type from api-processor instead of inline string literal.
  - **`packages/agents/.../package-version-builder-worker.ts`**: Same changes for the agents UI builder worker — added `getValidationLevel()` and passed the level to `builder.run()`.

  ## Behavior

  | `migrationInProgress` | Validation level | Effect |
  |---|---|---|
  | `true` | `major` | Publish allowed if major version matches; `previousVersionBuilderVersion` / `currentVersionBuilderVersion` recorded in build result |
  | `false` | `strict` | Publish blocked if api-processor versions differ at all (existing behavior) |
  | API error | `strict` | Fallback to existing behavior |

