### PR TITLE
feat: hide AI Assistant when aiChatEnabled is false

### DIFF
--- a/packages/portal/server/routers/system/system.ts
+++ b/packages/portal/server/routers/system/system.ts
@@ -22,6 +22,10 @@ export function getInfo(router: SystemRouter): void {
       backendVersion: '0.0.0',
       frontendVersion: '0.0.0',
       productionMode: false,
+      aiChatEnabled: true,
+      featureFlags: {
+        useV3Search: false,
+      },
     })
   })
 }

--- a/packages/portal/src/routes/root/BasePage/BasePage.tsx
+++ b/packages/portal/src/routes/root/BasePage/BasePage.tsx
@@ -45,7 +45,7 @@ import { PortalSettingsButton } from './PortalSettingsButton'
 import { UserPanel } from './UserPanel'
 
 export const BasePage: FC = memo(() => {
-  const { notification: systemNotification } = useSystemInfo()
+  const { notification: systemNotification, aiChatEnabled } = useSystemInfo()
   const showErrorNotification = useShowErrorNotification()
   const isSuperAdmin = useSuperAdminCheck()
   const { frontendVersion, apiProcessorVersion } = useVersionInfo()
@@ -73,49 +73,53 @@ export const BasePage: FC = memo(() => {
     [agentEnabled],
   )
 
+  const pageContent = (
+    <Box
+      display="grid"
+      gridTemplateRows="max-content 1fr"
+      height="100vh"
+    >
+      <AppHeader
+        logo={<LogoIcon />}
+        title="APIHUB"
+        links={links}
+        action={
+          <>
+            <VsCodeExtensionButton />
+            <AppHeaderDivider />
+            <SearchButton />
+            {aiChatEnabled && <AiAssistantButton />}
+            {isSuperAdmin && <PortalSettingsButton />}
+            <SystemInfoPopup
+              frontendVersionKey={frontendVersion}
+              apiProcessorVersion={apiProcessorVersion}
+            />
+            <UserPanel />
+          </>
+        }
+      />
+      <Box sx={viewPortStyleCalculator}>
+        <ExceptionSituationHandler
+          homePath="/portal"
+          showErrorNotification={showErrorNotification}
+          redirectUrlFactory={replacePackageId}
+        >
+          <Outlet />
+        </ExceptionSituationHandler>
+      </Box>
+      <Notification />
+      <GlobalSearchPanel />
+      {aiChatEnabled && <AiAssistantPanel />}
+      {systemNotification && <MaintenanceNotification value={systemNotification} />}
+    </Box>
+  )
+
   return (
     <MainPageProvider>
       <ModuleFetchingErrorBoundary showReloadPopup={packageJson.version !== frontendVersion}>
-        <AiAssistantProvider>
-          <Box
-            display="grid"
-            gridTemplateRows="max-content 1fr"
-            height="100vh"
-          >
-            <AppHeader
-              logo={<LogoIcon />}
-              title="APIHUB"
-              links={links}
-              action={
-                <>
-                  <VsCodeExtensionButton />
-                  <AppHeaderDivider />
-                  <SearchButton />
-                  <AiAssistantButton />
-                  {isSuperAdmin && <PortalSettingsButton />}
-                  <SystemInfoPopup
-                    frontendVersionKey={frontendVersion}
-                    apiProcessorVersion={apiProcessorVersion}
-                  />
-                  <UserPanel />
-                </>
-              }
-            />
-            <Box sx={viewPortStyleCalculator}>
-              <ExceptionSituationHandler
-                homePath="/portal"
-                showErrorNotification={showErrorNotification}
-                redirectUrlFactory={replacePackageId}
-              >
-                <Outlet />
-              </ExceptionSituationHandler>
-            </Box>
-            <Notification />
-            <GlobalSearchPanel />
-            <AiAssistantPanel />
-            {systemNotification && <MaintenanceNotification value={systemNotification} />}
-          </Box>
-        </AiAssistantProvider>
+        {aiChatEnabled
+          ? <AiAssistantProvider>{pageContent}</AiAssistantProvider>
+          : pageContent}
       </ModuleFetchingErrorBoundary>
     </MainPageProvider>
   )

--- a/packages/shared/src/utils/system-info.ts
+++ b/packages/shared/src/utils/system-info.ts
@@ -33,6 +33,7 @@ export type SystemInfo = {
   notification?: string
   migrationInProgress: boolean
   useV3Search: boolean
+  aiChatEnabled: boolean
 }
 
 type FeatureFlags = {
@@ -46,6 +47,7 @@ export type SystemInfoDto = {
   externalLinks: string[]
   notification?: string
   migrationInProgress: boolean
+  aiChatEnabled?: boolean
   featureFlags: FeatureFlags
 }
 
@@ -56,6 +58,7 @@ export const EMPTY_SYSTEM_INFO: SystemInfo = {
   externalLinks: [],
   migrationInProgress: false,
   useV3Search: false,
+  aiChatEnabled: false,
 }
 
 export function toSystemInfo(value: SystemInfoDto): SystemInfo {
@@ -79,6 +82,7 @@ export function toSystemInfo(value: SystemInfoDto): SystemInfo {
     notification: value.notification,
     migrationInProgress: value.migrationInProgress,
     useV3Search: value.featureFlags.useV3Search,
+    aiChatEnabled: value.aiChatEnabled ?? false,
   }
 }
 

--- a/packages/shared/src/utils/system-info.ts
+++ b/packages/shared/src/utils/system-info.ts
@@ -33,7 +33,7 @@ export type SystemInfo = {
   notification?: string
   migrationInProgress: boolean
   useV3Search: boolean
-  aiChatEnabled: boolean
+  aiChatEnabled?: boolean
 }
 
 type FeatureFlags = {
@@ -58,7 +58,6 @@ export const EMPTY_SYSTEM_INFO: SystemInfo = {
   externalLinks: [],
   migrationInProgress: false,
   useV3Search: false,
-  aiChatEnabled: false,
 }
 
 export function toSystemInfo(value: SystemInfoDto): SystemInfo {
@@ -82,7 +81,7 @@ export function toSystemInfo(value: SystemInfoDto): SystemInfo {
     notification: value.notification,
     migrationInProgress: value.migrationInProgress,
     useV3Search: value.featureFlags.useV3Search,
-    aiChatEnabled: value.aiChatEnabled ?? false,
+    aiChatEnabled: value.aiChatEnabled,
   }
 }
 


### PR DESCRIPTION
## Summary
- Consume `aiChatEnabled` from `/api/v1/system/info`
- Hide AI Assistant button and panel when the flag is false
- Default to hidden when the field is absent (backward compatible with older backends)

## Test plan
- [x] Against backend with `ai.chat.enabled: false`: no `AiAssistantButton` in portal header
- [x] Against backend with `ai.chat.enabled: true`: AI Assistant behaves as before
- [x] Verify global search, settings, and user menu still work when AI is hidden

Made with [Cursor](https://cursor.com)