### PR TITLE
build: reduce portal vite build peak memory

### DIFF
--- a/packages/portal/vite.config.ts
+++ b/packages/portal/vite.config.ts
@@ -108,6 +108,8 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       emptyOutDir: true,
+      // Skip gzip-compressing every chunk just to print its size: costly in memory and time on a large bundle.
+      reportCompressedSize: false,
       rollupOptions: {
         input: {
           app: resolve(__dirname, 'index.html'),

--- a/packages/portal/vite.config.ts
+++ b/packages/portal/vite.config.ts
@@ -19,11 +19,14 @@ const devServer = 'http://localhost:3003'
 
 export default defineConfig(({ mode }) => {
   const isProxyMode = mode === 'proxy'
+  // Bundle-size report is opt-in: set ANALYZE=1. Generating it holds the full module
+  // graph in memory and renders an HTML treemap, which inflates build memory and time.
+  const analyzeBundle = process.env.ANALYZE === 'true' || process.env.ANALYZE === '1'
 
   return {
     plugins: [
       react({ fastRefresh: false }),
-      bundleVisualizer(),
+      analyzeBundle && bundleVisualizer(),
       ignoreDotsOnDevServer(),
       monacoEditor({
         languageWorkers: ['editorWorkerService', 'json'],


### PR DESCRIPTION
## Why

The portal `vite build` is memory-heavy and has hit the Node heap limit in CI (e.g. [this run](https://github.com/asatt/qubership-apihub-ui/actions/runs/27948436862/job/82698995877) at `--max-old-space-size=4096`). Two parts of the build inflate peak heap and build time without any value for the shipped artifact.

## What

- **Gate `rollup-plugin-visualizer` behind `ANALYZE=1`.** It ran on every build, including CI, keeping the whole module-size graph in memory and rendering an HTML treemap. Its output, `stats.html` at the package root, is already gitignored and never shipped — the npm tarball includes only `/dist` — so gating it changes nothing in the artifact.
- **Set `build.reportCompressedSize: false`.** Vite gzip-compresses every output chunk just to print its size; on a Monaco-sized bundle that costs memory and time for an informational figure.

Two separate commits, so either can be reverted independently. No breaking changes.

## How to verify

- `npm run build -w @netcracker/qubership-apihub-ui-portal` — completes; no `stats.html` is written and the report has no compressed-size column.
- `ANALYZE=1 npm run build -w @netcracker/qubership-apihub-ui-portal` — `stats.html` is produced again.