### PR TITLE
fix: remove deprecated search scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mui/private-theming": "5.11.9",
     "@netcracker/qubership-apihub-api-diff": "dev",
     "@netcracker/qubership-apihub-api-doc-viewer": "dev",
-    "@netcracker/qubership-apihub-api-processor": "dev",
+    "@netcracker/qubership-apihub-api-processor": "feature-remove-deprecated-search-scopes",
     "@netcracker/qubership-apihub-api-unifier": "dev",
     "@netcracker/qubership-apihub-api-visitor": "dev",
     "@netcracker/qubership-apihub-apispec-view": "dev",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mui/private-theming": "5.11.9",
     "@netcracker/qubership-apihub-api-diff": "dev",
     "@netcracker/qubership-apihub-api-doc-viewer": "dev",
-    "@netcracker/qubership-apihub-api-processor": "feature-remove-deprecated-search-scopes",
+    "@netcracker/qubership-apihub-api-processor": "dev",
     "@netcracker/qubership-apihub-api-unifier": "dev",
     "@netcracker/qubership-apihub-api-visitor": "dev",
     "@netcracker/qubership-apihub-apispec-view": "dev",

--- a/packages/portal/server/routers/system/system.ts
+++ b/packages/portal/server/routers/system/system.ts
@@ -23,9 +23,6 @@ export function getInfo(router: SystemRouter): void {
       frontendVersion: '0.0.0',
       productionMode: false,
       aiChatEnabled: true,
-      featureFlags: {
-        useV3Search: false,
-      },
     })
   })
 }

--- a/packages/portal/src/entities/global-search.ts
+++ b/packages/portal/src/entities/global-search.ts
@@ -20,11 +20,6 @@ import type { VersionStatus } from '@netcracker/qubership-apihub-ui-shared/entit
 import type { MethodType } from '@netcracker/qubership-apihub-ui-shared/entities/method-types'
 import type { SpecType } from '@netcracker/qubership-apihub-ui-shared/utils/specs'
 import type { ApiType } from '@netcracker/qubership-apihub-ui-shared/entities/api-types'
-import {
-  API_TYPE_ASYNCAPI,
-  API_TYPE_GRAPHQL,
-  API_TYPE_REST,
-} from '@netcracker/qubership-apihub-ui-shared/entities/api-types'
 import type { ApiKind, Operation } from '@netcracker/qubership-apihub-ui-shared/entities/operations'
 import type { ApiAudience } from '@netcracker/qubership-apihub-api-processor'
 
@@ -135,49 +130,9 @@ export type Level =
   | typeof OPERATION_LEVEL
   | typeof DOCUMENT_LEVEL
 
-export const REQUEST_SCOPE = 'request'
-export const RESPONSE_SCOPE = 'response'
-
-export const ARGUMENT_SCOPE = 'argument'
-export const PROPERTY_SCOPE = 'property'
-export const ANNOTATION_SCOPE = 'annotation'
-
-export const PROPERTIES_AND_PARAMETER_DETAILED_SCOPE = 'Properties / Parameter'
-export const PROPERTIES_DETAILED_SCOPE = 'properties'
-export const ANNOTATION_DETAILED_SCOPE = 'annotation'
-export const EXAMPLES_DETAILED_SCOPE = 'examples'
-
 export const QUERY_OPERATION_TYPES = 'query'
 export const MUTATION_OPERATION_TYPES = 'mutation'
 export const SUBSCRIPTION_OPERATION_TYPES = 'subscription'
-
-export const MESSAGE_SCOPE = 'message'
-export const CHANNEL_SCOPE = 'channel'
-
-export type RestScope =
-  | typeof REQUEST_SCOPE
-  | typeof RESPONSE_SCOPE
-
-export type GraphqlScope =
-  | typeof ARGUMENT_SCOPE
-  | typeof PROPERTY_SCOPE
-  | typeof ANNOTATION_SCOPE
-
-export type AsyncApiScope =
-  | typeof MESSAGE_SCOPE
-  | typeof CHANNEL_SCOPE
-
-export type Scopes = RestScope | GraphqlScope | AsyncApiScope
-
-export type RestDetailedScope =
-  | typeof PROPERTIES_DETAILED_SCOPE
-  | typeof ANNOTATION_DETAILED_SCOPE
-  | typeof EXAMPLES_DETAILED_SCOPE
-
-export type OptionRestDetailedScope =
-  | typeof PROPERTIES_AND_PARAMETER_DETAILED_SCOPE
-  | typeof ANNOTATION_DETAILED_SCOPE
-  | typeof EXAMPLES_DETAILED_SCOPE
 
 export type GraphQlOperationTypes =
   | typeof QUERY_OPERATION_TYPES
@@ -188,50 +143,10 @@ export type SearchCriteria = {
   searchString: string
   packageIds?: Key[]
   versions?: Key[]
-  statuses?: VersionStatus[]
   status?: VersionStatus
   creationDateInterval?: {
     startDate: string
     endDate: string
   }
-  operationParams?: SearchRestParams | SearchGQLParams
   apiType?: ApiType
-}
-
-export type SearchRestParams = Partial<{
-  apiType: ApiType
-  scope: Scopes[]
-  detailedScope: RestDetailedScope[]
-  methods: MethodType[]
-}>
-
-export type SearchGQLParams = Partial<{
-  apiType: ApiType
-  scope: Scopes[]
-  operationTypes: GraphQlOperationTypes[]
-}>
-
-export type SearchAsyncApiParams = Partial<{
-  apiType: ApiType
-  scope: Scopes[]
-}>
-
-export const REST_SCOPES: RestScope[] = [RESPONSE_SCOPE, REQUEST_SCOPE]
-export const GRAPHQL_SCOPES: GraphqlScope[] = [ARGUMENT_SCOPE, PROPERTY_SCOPE, ANNOTATION_SCOPE]
-export const ASYNCAPI_SCOPES: AsyncApiScope[] = [MESSAGE_SCOPE, CHANNEL_SCOPE]
-
-export const API_TYPE_SCOPES_MAP: Record<ApiType, RestScope[] | GraphqlScope[] | AsyncApiScope[]> = {
-  [API_TYPE_REST]: REST_SCOPES,
-  [API_TYPE_GRAPHQL]: GRAPHQL_SCOPES,
-  [API_TYPE_ASYNCAPI]: ASYNCAPI_SCOPES,
-}
-
-export const OPERATIONS_TYPES: GraphQlOperationTypes[] = [QUERY_OPERATION_TYPES, MUTATION_OPERATION_TYPES, SUBSCRIPTION_OPERATION_TYPES]
-
-export const DETAILED_SCOPES: OptionRestDetailedScope[] = [PROPERTIES_AND_PARAMETER_DETAILED_SCOPE, ANNOTATION_DETAILED_SCOPE, EXAMPLES_DETAILED_SCOPE]
-
-export const detailedScopeMapping: Record<OptionRestDetailedScope, RestDetailedScope> = {
-  [PROPERTIES_AND_PARAMETER_DETAILED_SCOPE]: PROPERTIES_DETAILED_SCOPE,
-  [ANNOTATION_DETAILED_SCOPE]: ANNOTATION_DETAILED_SCOPE,
-  [EXAMPLES_DETAILED_SCOPE]: EXAMPLES_DETAILED_SCOPE,
 }

--- a/packages/portal/src/routes/EventBusProvider.tsx
+++ b/packages/portal/src/routes/EventBusProvider.tsx
@@ -121,7 +121,6 @@ export type ButtonType = {
 
 export type GlobalSearchPanelDetails = {
   filters: Omit<SearchCriteria, 'searchString'>
-  apiSearchMode?: boolean
 }
 
 export type ShowCreatePackageDetail = {

--- a/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/SearchFilters.tsx
+++ b/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/SearchFilters.tsx
@@ -26,35 +26,13 @@ import DatePicker from 'react-multi-date-picker'
 
 import { usePackages } from '@netcracker/qubership-apihub-ui-shared/hooks/packages/usePackages'
 import { useDebounce } from 'react-use'
-import type {
-  GraphQlOperationTypes,
-  OptionRestDetailedScope,
-  Scopes,
-  SearchAsyncApiParams,
-  SearchGQLParams,
-  SearchRestParams,
-} from '@apihub/entities/global-search'
-import {
-  ANNOTATION_SCOPE,
-  ARGUMENT_SCOPE,
-  detailedScopeMapping,
-  MUTATION_OPERATION_TYPES,
-  PROPERTY_SCOPE,
-  QUERY_OPERATION_TYPES,
-  REQUEST_SCOPE,
-  RESPONSE_SCOPE,
-  SUBSCRIPTION_OPERATION_TYPES,
-} from '@apihub/entities/global-search'
 import type { Key } from '@netcracker/qubership-apihub-ui-shared/entities/keys'
 import type { VersionStatus } from '@netcracker/qubership-apihub-ui-shared/entities/version-status'
 import {
-  ARCHIVED_VERSION_STATUS,
-  DRAFT_VERSION_STATUS,
   PUBLISH_STATUSES,
   RELEASE_VERSION_STATUS,
   VERSION_STATUSES,
 } from '@netcracker/qubership-apihub-ui-shared/entities/version-status'
-import type { MethodType } from '@netcracker/qubership-apihub-ui-shared/entities/method-types'
 import type { Package } from '@netcracker/qubership-apihub-ui-shared/entities/packages'
 import { GROUP_KIND, PACKAGE_KIND, WORKSPACE_KIND } from '@netcracker/qubership-apihub-ui-shared/entities/packages'
 import { handleVersionsRevision } from '@netcracker/qubership-apihub-ui-shared/utils/versions'
@@ -65,14 +43,11 @@ import { CustomChip } from '@netcracker/qubership-apihub-ui-shared/components/Cu
 import { CalendarIcon } from '@netcracker/qubership-apihub-ui-shared/icons/CalendarIcon'
 import type { ApiType } from '@netcracker/qubership-apihub-ui-shared/entities/api-types'
 import {
-  API_TYPE_ASYNCAPI,
-  API_TYPE_GRAPHQL,
   API_TYPE_REST,
   API_TYPE_TITLE_MAP,
   API_TYPES,
 } from '@netcracker/qubership-apihub-ui-shared/entities/api-types'
 import { DEFAULT_DEBOUNCE } from '@netcracker/qubership-apihub-ui-shared/utils/constants'
-import { useSystemInfo } from '@netcracker/qubership-apihub-ui-shared/features/system-info'
 import { usePackage } from '@apihub/routes/root/usePackage'
 import { toISODateRange } from '@netcracker/qubership-apihub-ui-shared/utils/date'
 import {
@@ -89,10 +64,6 @@ type FiltersData = Partial<{
   status: VersionStatus
   publicationDatePeriod: string[]
   apiType: ApiType
-  scope: Scopes[]
-  detailedScope: OptionRestDetailedScope[]
-  operationTypes: GraphQlOperationTypes[]
-  methods: MethodType[]
 }>
 
 type SearchFilters = {
@@ -142,14 +113,10 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
   }, [defaultPublicationDatePeriod, defaultWorkspace, reset])
 
   const {
-    operationTypes,
     apiType,
-    methods,
     version,
     status,
     publicationDatePeriod,
-    detailedScope,
-    scope,
   } = watch()
 
   const workspaceKey = watch().workspace?.key
@@ -210,8 +177,6 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
     setValue('publicationDatePeriod', toISODateRange(start, end))
   }, [setValue])
 
-  const { useV3Search } = useSystemInfo()
-
   const packageIdsDataForPackageAndGroup = useMemo(() => {
     if (packageKey) {
       return [packageKey]
@@ -233,69 +198,23 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
 
       const versionData = version ? [version] : []
 
-      const packageIdsData = (): string[] => {
-        if (packageKey || groupKey) {
-          return packageIdsDataForPackageAndGroup
-        }
-        if (workspaceKey) {
-          return [workspaceKey]
-        }
-        return []
+      const globalSearchFilter = {
+        filters: {
+          workspace: workspaceKey,
+          packageIds: packageIdsDataForPackageAndGroup,
+          versions: versionData,
+          status: status as VersionStatus,
+          creationDateInterval: {
+            startDate: publicationDatePeriod?.[0] ?? '',
+            endDate: publicationDatePeriod?.[1] ?? '',
+          },
+          apiType: apiType,
+        },
       }
-      const restDetailedScope = detailedScope?.map(scope => detailedScopeMapping[scope])
-
-      const apiTypeOperationsParams: Record<ApiType, SearchRestParams | SearchGQLParams> =
-        {
-          [API_TYPE_REST]: {
-            apiType: apiType,
-            scope: [REQUEST_SCOPE, RESPONSE_SCOPE],
-            detailedScope: restDetailedScope,
-            methods: methods,
-          } satisfies SearchRestParams,
-          [API_TYPE_GRAPHQL]: {
-            apiType: apiType,
-            scope: [ARGUMENT_SCOPE, PROPERTY_SCOPE, ANNOTATION_SCOPE],
-            operationTypes: [QUERY_OPERATION_TYPES, MUTATION_OPERATION_TYPES, SUBSCRIPTION_OPERATION_TYPES],
-          } satisfies SearchGQLParams,
-          [API_TYPE_ASYNCAPI]: {
-            apiType: apiType,
-          } as SearchAsyncApiParams,
-        }
-
-      const globalSearchFilter = useV3Search
-        ? {
-          filters: {
-            packageIds: packageIdsData(),
-            versions: versionData,
-            statuses: [DRAFT_VERSION_STATUS, RELEASE_VERSION_STATUS, ARCHIVED_VERSION_STATUS] as VersionStatus[],
-            creationDateInterval: {
-              startDate: publicationDatePeriod?.[0] ?? '',
-              endDate: publicationDatePeriod?.[1] ?? '',
-            },
-            operationParams:
-              apiType
-                ? apiTypeOperationsParams[apiType]
-                : {},
-          },
-          apiSearchMode: true,
-        }
-        : {
-          filters: {
-            workspace: workspaceKey,
-            packageIds: packageIdsDataForPackageAndGroup,
-            versions: versionData,
-            status: status as VersionStatus,
-            creationDateInterval: {
-              startDate: publicationDatePeriod?.[0] ?? '',
-              endDate: publicationDatePeriod?.[1] ?? '',
-            },
-            apiType: apiType,
-          },
-        }
 
       applyGlobalSearchFilters(globalSearchFilter)
     }),
-    [handleSubmit, detailedScope, methods, useV3Search, workspaceKey, packageIdsDataForPackageAndGroup, applyGlobalSearchFilters, packageKey, groupKey],
+    [handleSubmit, workspaceKey, packageIdsDataForPackageAndGroup, applyGlobalSearchFilters],
   )
 
   useDebounce(
@@ -304,12 +223,8 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
     [
       workspaceKey,
       groupKey,
-      operationTypes,
       packageKey,
       apiType,
-      detailedScope,
-      methods,
-      scope,
       status,
       version,
       publicationDatePeriod,
@@ -337,10 +252,6 @@ export const SearchFilters: FC<SearchFilters> = memo(({ enabledFilters }) => {
             </ListItem>
           )}
           onChange={(_, type) => {
-            setValue('scope', [])
-            setValue('detailedScope', [])
-            setValue('methods', [])
-            setValue('operationTypes', [])
             onChange(type)
           }}
           renderInput={(params) => (

--- a/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/global-search.ts
+++ b/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/global-search.ts
@@ -28,7 +28,7 @@ import type {
   SearchResultsDto,
 } from '../../../../entities/global-search'
 import { optionalSearchParams } from '@netcracker/qubership-apihub-ui-shared/utils/search-params'
-import { API_V3, API_V4, requestJson } from '@netcracker/qubership-apihub-ui-shared/utils/requests'
+import { API_V4, requestJson } from '@netcracker/qubership-apihub-ui-shared/utils/requests'
 import { getOptionalBody } from '@netcracker/qubership-apihub-ui-shared/utils/request-bodies'
 
 export type FetchNextSearchResultList = (options?: FetchNextPageOptions) => Promise<InfiniteQueryObserverResult<SearchResults, Error>>
@@ -38,7 +38,6 @@ export async function getSearchResult(
   level: Level,
   limit: number,
   page: number,
-  useV3Search: boolean,
 ): Promise<SearchResults> {
 
   const queryParams = optionalSearchParams({
@@ -50,7 +49,7 @@ export async function getSearchResult(
     method: 'POST',
     body: JSON.stringify(getOptionalBody(criteria)),
   }, {
-    basePath: useV3Search ? API_V3 : API_V4,
+    basePath: API_V4,
   })
 
   return toSearchResults(searchResultsDto)

--- a/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/useDocumentsGlobalSearch.ts
+++ b/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/useDocumentsGlobalSearch.ts
@@ -21,7 +21,6 @@ import { useMemo } from 'react'
 import type { SearchCriteria, SearchResults } from '@apihub/entities/global-search'
 import { DOCUMENT_LEVEL } from '@apihub/entities/global-search'
 import type { HasNextPage, IsFetchingNextPage, IsLoading } from '@netcracker/qubership-apihub-ui-shared/utils/aliases'
-import { useSystemInfo } from '@netcracker/qubership-apihub-ui-shared/features/system-info'
 
 const GLOBAL_DOCUMENTS_SEARCH_RESULT_QUERY_KEY = 'global-documents-search-result-query-key'
 
@@ -32,7 +31,6 @@ export function useDocumentsGlobalSearch(options: {
   page?: number
 }): [SearchResults, IsLoading, FetchNextSearchResultList, IsFetchingNextPage, HasNextPage] {
   const { criteria, page = 1, limit = 100, enabled } = options
-  const { useV3Search } = useSystemInfo()
 
   const {
     data,
@@ -42,7 +40,7 @@ export function useDocumentsGlobalSearch(options: {
     hasNextPage,
   } = useInfiniteQuery<SearchResults, Error, SearchResults>({
     queryKey: [GLOBAL_DOCUMENTS_SEARCH_RESULT_QUERY_KEY, criteria, DOCUMENT_LEVEL],
-    queryFn: ({ pageParam = page }) => getSearchResult(criteria, DOCUMENT_LEVEL, limit, pageParam - 1, useV3Search),
+    queryFn: ({ pageParam = page }) => getSearchResult(criteria, DOCUMENT_LEVEL, limit, pageParam - 1),
     enabled: enabled && !!criteria.searchString,
     getNextPageParam: (lastPage, allPages) => {
       if (limit && enabled) {

--- a/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/useOperationsGlobalSearch.ts
+++ b/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/useOperationsGlobalSearch.ts
@@ -21,7 +21,6 @@ import { useMemo } from 'react'
 import type { SearchCriteria, SearchResults } from '@apihub/entities/global-search'
 import { OPERATION_LEVEL } from '@apihub/entities/global-search'
 import type { HasNextPage, IsFetchingNextPage, IsLoading } from '@netcracker/qubership-apihub-ui-shared/utils/aliases'
-import { useSystemInfo } from '@netcracker/qubership-apihub-ui-shared/features/system-info'
 
 const GLOBAL_OPERATIONS_SEARCH_RESULT_QUERY_KEY = 'global-operations-search-result-query-key'
 
@@ -32,7 +31,6 @@ export function useOperationsGlobalSearch(options: {
   page?: number
 }): [SearchResults, IsLoading, FetchNextSearchResultList, IsFetchingNextPage, HasNextPage] {
   const { criteria, enabled, page = 1, limit = 100 } = options
-  const { useV3Search } = useSystemInfo()
 
   const {
     data,
@@ -42,7 +40,7 @@ export function useOperationsGlobalSearch(options: {
     hasNextPage,
   } = useInfiniteQuery<SearchResults, Error, SearchResults>({
     queryKey: [GLOBAL_OPERATIONS_SEARCH_RESULT_QUERY_KEY, criteria, OPERATION_LEVEL],
-    queryFn: ({ pageParam = page }) => getSearchResult(criteria, OPERATION_LEVEL, limit, pageParam - 1, useV3Search),
+    queryFn: ({ pageParam = page }) => getSearchResult(criteria, OPERATION_LEVEL, limit, pageParam - 1),
     enabled: enabled && !!criteria.searchString,
     getNextPageParam: (lastPage, allPages) => {
       if (limit && enabled) {

--- a/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/usePackagesGlobalSearch.ts
+++ b/packages/portal/src/routes/root/BasePage/GlobalSearchPanel/usePackagesGlobalSearch.ts
@@ -21,7 +21,6 @@ import { useMemo } from 'react'
 import type { SearchCriteria, SearchResults } from '@apihub/entities/global-search'
 import { PACKAGE_LEVEL } from '@apihub/entities/global-search'
 import type { HasNextPage, IsFetchingNextPage, IsLoading } from '@netcracker/qubership-apihub-ui-shared/utils/aliases'
-import { useSystemInfo } from '@netcracker/qubership-apihub-ui-shared/features/system-info'
 
 const GLOBAL_PACKAGES_SEARCH_RESULT_QUERY_KEY = 'global-packages-search-result-query-key'
 
@@ -32,7 +31,6 @@ export function usePackagesGlobalSearch(options: {
   page?: number
 }): [SearchResults, IsLoading, FetchNextSearchResultList, IsFetchingNextPage, HasNextPage] {
   const { criteria, enabled, page = 1, limit = 100 } = options
-  const { useV3Search } = useSystemInfo()
 
   const {
     data,
@@ -42,7 +40,7 @@ export function usePackagesGlobalSearch(options: {
     hasNextPage,
   } = useInfiniteQuery<SearchResults, Error, SearchResults>({
     queryKey: [GLOBAL_PACKAGES_SEARCH_RESULT_QUERY_KEY, criteria, PACKAGE_LEVEL],
-    queryFn: ({ pageParam = page }) => getSearchResult(criteria, PACKAGE_LEVEL, limit, pageParam - 1, useV3Search),
+    queryFn: ({ pageParam = page }) => getSearchResult(criteria, PACKAGE_LEVEL, limit, pageParam - 1),
     enabled: enabled && !!criteria.searchString,
     getNextPageParam: (lastPage, allPages) => {
       if (limit && enabled) {

--- a/packages/shared/src/utils/system-info.ts
+++ b/packages/shared/src/utils/system-info.ts
@@ -32,12 +32,7 @@ export type SystemInfo = {
   externalLinks: Link[]
   notification?: string
   migrationInProgress: boolean
-  useV3Search: boolean
   aiChatEnabled?: boolean
-}
-
-type FeatureFlags = {
-  useV3Search: boolean
 }
 
 export type SystemInfoDto = {
@@ -48,7 +43,6 @@ export type SystemInfoDto = {
   notification?: string
   migrationInProgress: boolean
   aiChatEnabled?: boolean
-  featureFlags: FeatureFlags
 }
 
 export const EMPTY_SYSTEM_INFO: SystemInfo = {
@@ -57,7 +51,6 @@ export const EMPTY_SYSTEM_INFO: SystemInfo = {
   productionMode: false,
   externalLinks: [],
   migrationInProgress: false,
-  useV3Search: false,
 }
 
 export function toSystemInfo(value: SystemInfoDto): SystemInfo {
@@ -80,7 +73,6 @@ export function toSystemInfo(value: SystemInfoDto): SystemInfo {
     externalLinks: externalLinks,
     notification: value.notification,
     migrationInProgress: value.migrationInProgress,
-    useV3Search: value.featureFlags.useV3Search,
     aiChatEnabled: value.aiChatEnabled,
   }
 }


### PR DESCRIPTION
## Summary
Global Search v4 uses stored per-operation `searchText` as its data source. The
older scope-based search (v3) is no longer used, so this PR removes the v3 search
scope machinery from the UI. The change is confined to the Global Search feature.

## What changed
- Drop the `useV3Search` feature flag end-to-end (`SystemInfoDto.featureFlags`,
  `SystemInfo`, `EMPTY_SYSTEM_INFO`, `toSystemInfo`, and the dev `system` router).
- Remove the v3 scope model from `entities/global-search.ts`: `RestScope` /
  `GraphqlScope` / `AsyncApiScope`, detailed-scope types and mappings,
  `SearchRestParams` / `SearchGQLParams` / `SearchAsyncApiParams`,
  `API_TYPE_SCOPES_MAP`, and the related `*_SCOPES` constants.
- Trim `SearchCriteria`: remove `operationParams`, `statuses`, and the
  `apiSearchMode` detail from the Global Search event payload.
- Simplify `GlobalSearchPanel/SearchFilters.tsx` (remove the detailed-scope
  filter UI) and the `useDocuments/useOperations/usePackagesGlobalSearch` hooks.

## Why
The v3/fts/lite scopes are not consumed by the backend anymore; v4 search relies
solely on `searchText`. This is cleanup of dead code paths.

## Notes
- UI-only, scoped to Global Search. No changes to publishing, comparison,
  operations, or export flows.
