### PR TITLE
fix: forward client IP headers to backend

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -63,6 +63,8 @@ http {
         proxy_http_version 1.1;
         proxy_set_header Upgrade     $http_upgrade;
         proxy_set_header Connection  $connection_upgrade;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_redirect off;
         port_in_redirect off;
         absolute_redirect  off;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -63,7 +63,6 @@ http {
         proxy_http_version 1.1;
         proxy_set_header Upgrade     $http_upgrade;
         proxy_set_header Connection  $connection_upgrade;
-        proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_redirect off;
         port_in_redirect off;


### PR DESCRIPTION
## Summary

Forward the client IP to backend services by setting `X-Forwarded-For` on all nginx upstream proxy requests. This enables the backend to log the requestor IP for unknown-endpoint requests ([qubership-apihub#607](https://github.com/Netcracker/qubership-apihub/issues/607)).

## Problem

The UI nginx reverse proxy did not explicitly set `X-Forwarded-For` when proxying to the backend. Without it, upstream services only see the nginx pod/container address, so backend logs cannot attribute requests (e.g. external systems hitting incorrect endpoints) to the actual client.

## Solution

Add a server-level directive so every `proxy_pass` location inherits it:

```nginx
proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
```

`$proxy_add_x_forwarded_for` is the standard nginx variable: it preserves any existing `X-Forwarded-For` chain from an upstream load balancer/ingress and appends `$remote_addr` for this hop.

Only `X-Forwarded-For` is set — not `X-Real-IP` — because `$proxy_add_x_forwarded_for` already includes `$remote_addr`, making a separate `X-Real-IP` redundant.

## Test plan

- [ ] Deploy UI with this nginx config behind the usual ingress/LB topology
- [ ] Send a request to an unknown API path (e.g. `/api/v1/nonexistent`)
- [ ] Confirm backend logs show the expected client IP from `X-Forwarded-For`
- [ ] Confirm existing API, WebSocket, and SAML proxy routes still work (CI e2e already passes)