### PR TITLE
fix: rename 'Cancel' button to 'Reset' for 'Role hierarchy' tab on Portal settings

### DIFF
--- a/packages/portal/src/routes/root/RolesHierarchySettingsTab.tsx
+++ b/packages/portal/src/routes/root/RolesHierarchySettingsTab.tsx
@@ -75,7 +75,7 @@ export const RolesHierarchySettingsTab: FC = memo(() => {
             disabled={!isChanged}
             sx={{ width: '100px' }}
           >
-            Cancel
+            Reset
           </Button>
         </Box>
       }


### PR DESCRIPTION
… tab on Portal settings