### PR TITLE
build: exclude bundle analyzer from production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "npx lerna run build",
+    "build:analyze": "npx lerna run build:analyze",
     "build:showcase": "npm run --workspace=@netcracker/qubership-apihub-ui-shared build:showcase",
     "test": "npm run test --workspace=@netcracker/qubership-apihub-ui-shared",
     "development:link": "npm link @netcracker/qubership-apihub-api-processor",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -6,7 +6,10 @@
     "/dist"
   ],
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "npm run build:tsc && npm run build:vite",
+    "build:tsc": "tsc",
+    "build:vite": "vite build",
+    "build:analyze": "npm run build:tsc && npm run build:vite -- --mode analyze",
     "dev:backend": "nodemon server/index.ts",
     "dev:frontend": "vite --host --force",
     "proxy": "vite --host --mode=proxy",

--- a/packages/agents/vite.config.ts
+++ b/packages/agents/vite.config.ts
@@ -25,17 +25,24 @@ import { VitePluginFonts } from 'vite-plugin-fonts'
 import { visualizer as bundleVisualizer } from 'rollup-plugin-visualizer'
 import createVersionJsonFilePlugin from '../../vite-create-version-json'
 
-const proxyServer = 'http://host.docker.internal:8081'
+const proxyServer = 'https://qubership-apihub.localtest.me/'
 const devServer = 'http://localhost:3003'
 
 export default defineConfig(({ mode }) => {
   const isProxyMode = mode === 'proxy'
+  // Bundle-size analysis is opt-in via `npm run build:analyze` (which passes `--mode analyze`).
+  // It is kept out of the default build because generating the report holds the full module graph
+  // in memory and renders an HTML treemap, which inflates build memory and time — the portal CI
+  // build has hit the Node heap limit during this phase.
+  // Note: a custom mode does NOT make this a non-production build. Vite derives `isProduction`
+  // from NODE_ENV, and `vite build` defaults NODE_ENV to 'production' regardless of `--mode`.
+  const analyzeBundle = mode === 'analyze'
 
   return {
     base: !isProxyMode ? '/agents' : '',
     plugins: [
       react({ fastRefresh: false }),
-      bundleVisualizer(),
+      analyzeBundle && bundleVisualizer(),
       ignoreDotsOnDevServer(),
       monacoEditor({
         languageWorkers: ['editorWorkerService', 'json'],
@@ -101,6 +108,10 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       emptyOutDir: true,
+      // Gzip-compressing every chunk just to print its size costs build time on a bundle this large,
+      // so it is skipped by default. It is genuinely useful when analyzing the bundle, so it is
+      // enabled together with the visualizer under `npm run build:analyze`.
+      reportCompressedSize: analyzeBundle,
       rollupOptions: {
         input: {
           app: resolve(__dirname, 'index.html'),

--- a/packages/agents/vite.config.ts
+++ b/packages/agents/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig(({ mode }) => {
     base: !isProxyMode ? '/agents' : '',
     plugins: [
       react({ fastRefresh: false }),
-      analyzeBundle && bundleVisualizer(),
+      ...(analyzeBundle ? [bundleVisualizer()] : []),
       ignoreDotsOnDevServer(),
       monacoEditor({
         languageWorkers: ['editorWorkerService', 'json'],

--- a/packages/agents/vite.config.ts
+++ b/packages/agents/vite.config.ts
@@ -25,7 +25,7 @@ import { VitePluginFonts } from 'vite-plugin-fonts'
 import { visualizer as bundleVisualizer } from 'rollup-plugin-visualizer'
 import createVersionJsonFilePlugin from '../../vite-create-version-json'
 
-const proxyServer = 'https://qubership-apihub.localtest.me/'
+const proxyServer = 'http://host.docker.internal:8081'
 const devServer = 'http://localhost:3003'
 
 export default defineConfig(({ mode }) => {

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -6,7 +6,10 @@
     "/dist"
   ],
   "scripts": {
-    "build": "tsc && tsc --project server/tsconfig.json && cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build",
+    "build": "npm run build:tsc && npm run build:vite",
+    "build:tsc": "tsc && tsc --project server/tsconfig.json",
+    "build:vite": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build",
+    "build:analyze": "npm run build:tsc && npm run build:vite -- --mode analyze",
     "dev:backend": "nodemon --watch server --ext ts,json server/index.ts",
     "dev:frontend": "vite --host --force",
     "proxy": "vite --host --mode=proxy --force",

--- a/packages/portal/vite.config.ts
+++ b/packages/portal/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       react({ fastRefresh: false }),
-      analyzeBundle && bundleVisualizer(),
+      ...(analyzeBundle ? [bundleVisualizer()] : []),
       ignoreDotsOnDevServer(),
       monacoEditor({
         languageWorkers: ['editorWorkerService', 'json'],

--- a/packages/portal/vite.config.ts
+++ b/packages/portal/vite.config.ts
@@ -19,11 +19,18 @@ const devServer = 'http://localhost:3003'
 
 export default defineConfig(({ mode }) => {
   const isProxyMode = mode === 'proxy'
+  // Bundle-size analysis is opt-in via `npm run build:analyze` (which passes `--mode analyze`).
+  // It is kept out of the default build because generating the report holds the full module graph
+  // in memory and renders an HTML treemap, which inflates build memory and time — the portal CI
+  // build has hit the Node heap limit during this phase.
+  // Note: a custom mode does NOT make this a non-production build. Vite derives `isProduction`
+  // from NODE_ENV, and `vite build` defaults NODE_ENV to 'production' regardless of `--mode`.
+  const analyzeBundle = mode === 'analyze'
 
   return {
     plugins: [
       react({ fastRefresh: false }),
-      bundleVisualizer(),
+      analyzeBundle && bundleVisualizer(),
       ignoreDotsOnDevServer(),
       monacoEditor({
         languageWorkers: ['editorWorkerService', 'json'],
@@ -111,6 +118,8 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       emptyOutDir: true,
+      // Skip gzip-compressing every chunk just to print its size: costly in memory and time on a large bundle.
+      reportCompressedSize: analyzeBundle,
       rollupOptions: {
         input: {
           app: resolve(__dirname, 'index.html'),


### PR DESCRIPTION
## Summary

- Gate `rollup-plugin-visualizer` and `reportCompressedSize` behind an opt-in `--mode analyze` flag in portal and agents vite configs, so they no longer run on every production build.
- Split package `build` scripts into `build:tsc` / `build:vite` and add `build:analyze` for bundle-size analysis when needed.
- Add root-level `build:analyze` script (`npx lerna run build:analyze`).

Previously, the bundle visualizer ran unconditionally during `vite build`, keeping the full module graph in memory and rendering an HTML treemap. On the portal package this contributed to CI hitting the Node heap limit. Production build output is unchanged — only dev/analysis tooling is skipped by default.

## Changes

| Area | Before | After |
|------|--------|-------|
| `rollup-plugin-visualizer` | Always enabled | Enabled only with `--mode analyze` |
| `reportCompressedSize` | Default (`true`) | `true` only in analyze mode |
| Analysis workflow | N/A | `npm run build:analyze` (per package or at repo root) |

`--mode analyze` does not affect production semantics: `vite build` sets `NODE_ENV=production` regardless of mode.

## Benchmark results

Measured locally on Windows (Node v24, 5 interleaved runs per mode, warmup + artifact cleanup between runs).

### Portal (`packages/portal`)

| Mode | Mean wall time | Mean peak memory |
|------|---------------:|-----------------:|
| `build` | 208.6 s | 7.21 GB |
| `build:analyze` | 215.6 s | 7.25 GB |
| **Δ** | **+7.0 s (+3.4%)** | **+46 MB (+0.6%)** |

### Whole monorepo (`npm run build` at root)

| Mode | Mean wall time | Mean peak memory |
|------|---------------:|-----------------:|
| `build` | 268.7 s | 10.43 GB |
| `build:analyze` | 276.7 s | 10.58 GB |
| **Δ** | **+8.0 s (+3.0%)** | **+148 MB (+1.4%)** |

Monorepo savings are smaller than portal-only impact because Lerna builds portal and agents in parallel and agents has a smaller bundle.

## Test plan

- [x] `npm run build` succeeds for portal and agents
- [x] `npm run build:analyze` succeeds for portal and agents
- [x] `npm run build` at repo root succeeds (Lerna)
- [x] CI build-and-unit-test, lint, docker image, e2e pass
- [ ] Verify `stats.html` is generated only after `build:analyze` (not after `build`)
- [ ] Confirm production `dist/` contents are unchanged vs pre-PR build