### PR TITLE
feat: align previous version status validation with backend

### DIFF
--- a/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/CopyPackageVersionDialog.tsx
@@ -29,14 +29,12 @@ import type { VersionStatus } from '@netcracker/qubership-apihub-ui-shared/entit
 import {
   DRAFT_VERSION_STATUS,
   NO_PREVIOUS_RELEASE_VERSION_OPTION,
-  RELEASE_VERSION_STATUS,
 } from '@netcracker/qubership-apihub-ui-shared/entities/version-status'
 import type { VersionFormData } from '@netcracker/qubership-apihub-ui-shared/components/VersionDialogForm'
 import {
   getPackageOptions,
   getVersionOptions,
   replaceEmptyPreviousVersion,
-  usePreviousVersionOptions,
   VersionDialogForm,
 } from '@netcracker/qubership-apihub-ui-shared/components/VersionDialogForm'
 import { usePackages } from '@apihub/routes/root/usePackages'
@@ -90,13 +88,6 @@ const CopyPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpe
     enabled: !!targetPackage,
     textFilter: versionsFilter,
   })
-  const { versions: targetPreviousVersions } = usePackageVersions({
-    packageKey: targetPackage?.key,
-    enabled: !!targetPackage,
-    status: RELEASE_VERSION_STATUS,
-  })
-
-  const targetPreviousVersionOptions = usePreviousVersionOptions(targetPreviousVersions)
   const [copyPackage, publishId, isCopyStarting, isCopyingStartedSuccessfully] = useCopyPackageVersion()
   const [isPublishing, isPublished] = usePublicationStatuses(targetPackage?.key ?? '', publishId, targetVersion)
 
@@ -190,7 +181,7 @@ const CopyPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, setOpe
       onSetTargetVersion={onSetTargetVersion}
       packagesTitle={kindTitle}
       versions={versionOptions}
-      previousVersions={targetPreviousVersionOptions}
+      previousVersionsPackageKey={targetPackage?.key}
       getVersionLabels={getVersionLabels}
       packagePermissions={targetPackagePermissions}
       releaseVersionPattern={targetReleaseVersionPattern}

--- a/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishDashboardVersionFromCSVDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishDashboardVersionFromCSVDialog.tsx
@@ -30,14 +30,12 @@ import type { VersionStatus } from '@netcracker/qubership-apihub-ui-shared/entit
 import {
   DRAFT_VERSION_STATUS,
   NO_PREVIOUS_RELEASE_VERSION_OPTION,
-  RELEASE_VERSION_STATUS,
 } from '@netcracker/qubership-apihub-ui-shared/entities/version-status'
 import type { VersionFormData } from '@netcracker/qubership-apihub-ui-shared/components/VersionDialogForm'
 import {
   getPackageOptions,
   getVersionOptions,
   replaceEmptyPreviousVersion,
-  usePreviousVersionOptions,
   VersionDialogForm,
 } from '@netcracker/qubership-apihub-ui-shared/components/VersionDialogForm'
 import { useDashboardVersionFromCSVPublicationStatuses } from '@apihub/routes/root/PortalPage/usePublicationStatus'
@@ -86,10 +84,6 @@ const PublishDashboardVersionFromCSVPopup: FC<PopupProps> = memo<PopupProps>(({ 
   const { versions: filteredVersions, areVersionsLoading: areFilteredVersionsLoading } = usePackageVersions({
     textFilter: versionsFilter,
   })
-  const { versions: targetPreviousVersions } = usePackageVersions({
-    status: RELEASE_VERSION_STATUS,
-  })
-  const previousVersionOptions = usePreviousVersionOptions(targetPreviousVersions)
   const versionLabelsMap = useMemo(() => getVersionLabelsMap(filteredVersions), [filteredVersions])
   const versionOptions = useMemo(() => getVersionOptions(versionLabelsMap, targetVersion), [targetVersion, versionLabelsMap])
   const workspaceOptions = useMemo(() => getPackageOptions(workspaces, targetWorkspace, !!workspacesFilter), [targetWorkspace, workspaces, workspacesFilter])
@@ -169,7 +163,7 @@ const PublishDashboardVersionFromCSVPopup: FC<PopupProps> = memo<PopupProps>(({ 
       versions={versionOptions}
       onVersionsFilter={onVersionsFilter}
       areVersionsLoading={areFilteredVersionsLoading}
-      previousVersions={previousVersionOptions}
+      previousVersionsPackageKey={currentPackage?.key}
       getVersionLabels={getVersionLabels}
       onSetTargetVersion={onSetTargetVersion}
       packagePermissions={packagePermissions}

--- a/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/DashboardPage/PublishPackageVersionDialog.tsx
@@ -35,13 +35,11 @@ import type { VersionStatus } from '@netcracker/qubership-apihub-ui-shared/entit
 import {
   DRAFT_VERSION_STATUS,
   NO_PREVIOUS_RELEASE_VERSION_OPTION,
-  RELEASE_VERSION_STATUS,
 } from '@netcracker/qubership-apihub-ui-shared/entities/version-status'
 import type { VersionFormData } from '@netcracker/qubership-apihub-ui-shared/components/VersionDialogForm'
 import {
   getVersionOptions,
   replaceEmptyPreviousVersion,
-  usePreviousVersionOptions,
   VersionDialogForm,
 } from '@netcracker/qubership-apihub-ui-shared/components/VersionDialogForm'
 import { takeIf } from '@netcracker/qubership-apihub-ui-shared/utils/objects'
@@ -81,8 +79,6 @@ const PublishPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, set
     versions: filteredVersions,
     areVersionsLoading: areFilteredVersionsLoading,
   } = usePackageVersions({ textFilter: versionsFilter })
-  const { versions: previousVersions } = usePackageVersions({ status: RELEASE_VERSION_STATUS })
-  const previousVersionOptions = usePreviousVersionOptions(previousVersions)
   const [publishPackage, isPublishLoading, isPublishSuccess] = usePublishPackageVersion()
   const dashboardRefs = useDashboardReferences()
 
@@ -156,7 +152,7 @@ const PublishPackageVersionPopup: FC<PopupProps> = memo<PopupProps>(({ open, set
       versions={versionOptions}
       onVersionsFilter={onVersionsFilter}
       areVersionsLoading={areFilteredVersionsLoading}
-      previousVersions={previousVersionOptions}
+      previousVersionsPackageKey={currentPackage?.key}
       getVersionLabels={getVersionLabels}
       packagePermissions={packagePermissions}
       releaseVersionPattern={releaseVersionPattern}

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/GeneralPackageSettingsTab/GeneralPackageSettingsTabEditor.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/GeneralPackageSettingsTab/GeneralPackageSettingsTabEditor.tsx
@@ -74,7 +74,7 @@ export const GeneralPackageSettingsTabEditor: FC<PackageSettingsTabProps> = memo
   const [updatePackage, isUpdateLoading, isSuccess] = useUpdatePackage()
   const { versions: previousReleaseVersions } = usePackageVersions({
     packageKey: key,
-    status: RELEASE_VERSION_STATUS,
+    status: [RELEASE_VERSION_STATUS],
   })
 
   const defaultReleaseVersion = useMemo(

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
@@ -51,7 +51,7 @@ export const PackageVersionsTable: FC<PackageVersionsTableProps> = memo<PackageV
 
   const { versions, areVersionsLoading, fetchNextPage, isFetchingNextPage, hasNextPage } = usePackageVersions({
     packageKey: packageKey,
-    status: status,
+    status: status ? [status] : undefined,
     textFilter: searchValue,
   })
 

--- a/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
+++ b/packages/portal/src/routes/root/PortalPage/PackageSettingsPage/VersionsPackageSettingsTab/PackageVersionsTable.tsx
@@ -48,10 +48,11 @@ export const PackageVersionsTable: FC<PackageVersionsTableProps> = memo<PackageV
     packageKey, permissions, status,
     onDelete, onEdit, searchValue,
   } = props
+  const statuses = useMemo(() => (status ? [status] : undefined), [status])
 
   const { versions, areVersionsLoading, fetchNextPage, isFetchingNextPage, hasNextPage } = usePackageVersions({
     packageKey: packageKey,
-    status: status ? [status] : undefined,
+    status: statuses,
     textFilter: searchValue,
   })
 

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOverviewSubPage/OperationGroupsCard/PublishOperationGroupPackageVersionDialog.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionOverviewSubPage/OperationGroupsCard/PublishOperationGroupPackageVersionDialog.tsx
@@ -25,7 +25,6 @@ import {
   getPackageOptions,
   getVersionOptions,
   replaceEmptyPreviousVersion,
-  usePreviousVersionOptions,
   VersionDialogForm,
 } from '@netcracker/qubership-apihub-ui-shared/components/VersionDialogForm'
 import { useForm } from 'react-hook-form'
@@ -33,7 +32,6 @@ import type { VersionStatus } from '@netcracker/qubership-apihub-ui-shared/entit
 import {
   DRAFT_VERSION_STATUS,
   NO_PREVIOUS_RELEASE_VERSION_OPTION,
-  RELEASE_VERSION_STATUS,
 } from '@netcracker/qubership-apihub-ui-shared/entities/version-status'
 import type { Package } from '@netcracker/qubership-apihub-ui-shared/entities/packages'
 import { PACKAGE_KIND, WORKSPACE_KIND } from '@netcracker/qubership-apihub-ui-shared/entities/packages'
@@ -76,11 +74,6 @@ const PublishOperationGroupPackageVersionPopup: FC<PopupProps> = memo<PopupProps
     kind: WORKSPACE_KIND,
     textFilter: workspacesFilter,
   })
-  const { versions: targetPreviousVersions } = usePackageVersions({
-    packageKey: targetPackage?.key,
-    enabled: !!targetPackage,
-    status: RELEASE_VERSION_STATUS,
-  })
 
   const [packages, arePackagesLoading] = usePackages({
     kind: PACKAGE_KIND,
@@ -94,7 +87,6 @@ const PublishOperationGroupPackageVersionPopup: FC<PopupProps> = memo<PopupProps
     textFilter: versionsFilter,
   })
 
-  const targetPreviousVersionOptions = usePreviousVersionOptions(targetPreviousVersions)
   const {
     publishId,
     publishOperationGroupPackageVersion,
@@ -189,7 +181,7 @@ const PublishOperationGroupPackageVersionPopup: FC<PopupProps> = memo<PopupProps
       onVersionsFilter={onVersionsFilter}
       areVersionsLoading={areFilteredVersionsLoading}
       getVersionLabels={getVersionLabels}
-      previousVersions={targetPreviousVersionOptions}
+      previousVersionsPackageKey={targetPackage?.key}
       onSetTargetVersion={onSetTargetVersion}
       packagePermissions={targetPackagePermissions}
       releaseVersionPattern={targetReleaseVersionPattern}

--- a/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
@@ -55,9 +55,10 @@ export const VersionSelector: FC = memo(() => {
   const [searchValue, setSearchValue] = useState('')
   const [anchor, setAnchor] = useState<HTMLElement>()
   const [activeTab, setActiveTab] = useState<VersionTab>(RELEASE_TAB)
+  const statuses = useMemo(() => [VERSION_STATUS_MAP[activeTab]], [activeTab])
 
   const { versions, areVersionsLoading } = usePackageVersions({
-    status: [VERSION_STATUS_MAP[activeTab]],
+    status: statuses,
     textFilter: searchValue,
     sortBy: VERSION_SORT_MAP[activeTab].sortBy,
     sortOrder: VERSION_SORT_MAP[activeTab].sortOrder,

--- a/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionSelector.tsx
@@ -57,7 +57,7 @@ export const VersionSelector: FC = memo(() => {
   const [activeTab, setActiveTab] = useState<VersionTab>(RELEASE_TAB)
 
   const { versions, areVersionsLoading } = usePackageVersions({
-    status: VERSION_STATUS_MAP[activeTab],
+    status: [VERSION_STATUS_MAP[activeTab]],
     textFilter: searchValue,
     sortBy: VERSION_SORT_MAP[activeTab].sortBy,
     sortOrder: VERSION_SORT_MAP[activeTab].sortOrder,

--- a/packages/shared/.storybook/preview.tsx
+++ b/packages/shared/.storybook/preview.tsx
@@ -21,6 +21,15 @@ import { CssBaseline, ThemeProvider } from '@mui/material'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { theme } from '../src/themes/theme'
 
+/**
+ * Stub client — Storybook never talks to a backend.
+ *
+ * It exists only so components that query on their own (VersionDialogForm, for example) can render:
+ * without a provider `useQuery` throws. No story actually fetches — each one supplies its data
+ * through props, which keeps the corresponding queries disabled — and no API proxy is configured for
+ * the Storybook dev server, so a stray request would only reach its own origin. `retry: false` keeps
+ * such a request from being repeated.
+ */
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const preview: Preview = {

--- a/packages/shared/.storybook/preview.tsx
+++ b/packages/shared/.storybook/preview.tsx
@@ -18,7 +18,10 @@ import React from 'react'
 import type { Preview } from '@storybook/react'
 import { MemoryRouter } from 'react-router-dom'
 import { CssBaseline, ThemeProvider } from '@mui/material'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { theme } from '../src/themes/theme'
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const preview: Preview = {
   parameters: {
@@ -26,12 +29,14 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <MemoryRouter>
-        <ThemeProvider theme={theme}>
-          <CssBaseline/>
-          <Story/>
-        </ThemeProvider>
-      </MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ThemeProvider theme={theme}>
+            <CssBaseline/>
+            <Story/>
+          </ThemeProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
     ),
   ],
 }

--- a/packages/shared/src/components/OptionItem.tsx
+++ b/packages/shared/src/components/OptionItem.tsx
@@ -17,7 +17,7 @@
 import type { FC, HTMLAttributes } from 'react'
 import * as React from 'react'
 import { memo } from 'react'
-import type { TooltipProps } from '@mui/material'
+import type { ChipProps, TooltipProps } from '@mui/material'
 import { Box, ListItem, Tooltip, Typography } from '@mui/material'
 import { OverflowTooltip } from './OverflowTooltip'
 import { CustomChip } from './CustomChip'
@@ -29,6 +29,7 @@ export type OptionItemProps = {
   disabled?: boolean
   subtitle?: string
   chipValue?: string
+  chipVariant?: ChipProps['variant']
   tooltipProps?: Omit<TooltipProps, 'children'>
 } & TestableProps
 
@@ -38,6 +39,7 @@ export const OptionItem: FC<OptionItemProps> = memo<OptionItemProps>(({
   disabled,
   subtitle,
   chipValue,
+  chipVariant = 'outlined',
   tooltipProps: { title: tooltipTitle, ...rest } = {},
   'data-testid': dataTestId,
 }) => {
@@ -66,7 +68,7 @@ export const OptionItem: FC<OptionItemProps> = memo<OptionItemProps>(({
                 </OverflowTooltip>
               )}
             </Box>
-            {chipValue && <CustomChip sx={{ marginLeft: 'auto' }} variant="outlined" value={chipValue}/>}
+            {chipValue && <CustomChip sx={{ marginLeft: 'auto' }} variant={chipVariant} value={chipValue}/>}
           </Box>
         </ListItem>
       </Box>

--- a/packages/shared/src/components/VersionDialogForm.tsx
+++ b/packages/shared/src/components/VersionDialogForm.tsx
@@ -42,7 +42,11 @@ import type { PackagePermissions } from '../entities/package-permissions'
 import type { VersionStatus } from '../entities/version-status'
 import {
   DRAFT_VERSION_STATUS,
+  getPreviousVersionLabels,
+  getPreviousVersionStatuses,
+  isPreviousVersionStatusAllowed,
   NO_PREVIOUS_RELEASE_VERSION_OPTION,
+  RELEASE_PREVIOUS_VERSION_REQUIRED_MESSAGE,
   RELEASE_VERSION_STATUS,
   VERSION_STATUS_MANAGE_PERMISSIONS,
   VERSION_STATUSES,
@@ -58,6 +62,7 @@ import { CloudUploadIcon } from '../icons/CloudUploadIcon'
 import { getSplittedVersionKey, handleVersionsRevision } from '../utils/versions'
 import { ErrorTypography } from './Typography/ErrorTypography'
 import type { PackageVersions } from '../entities/versions'
+import { usePackageVersions } from '../hooks/versions/usePackageVersions'
 import { LabelsAutocomplete } from './LabelsAutocomplete'
 import type { Package, Packages } from '../entities/packages'
 import { OptionItem } from './OptionItem'
@@ -113,7 +118,8 @@ export type VersionDialogFormProps<T extends VersionFormData = VersionFormData> 
   packageObj?: Package
   onSetPackage?: () => void
   versions?: Key[]
-  previousVersions?: Key[]
+  previousVersionsPackageKey?: Key
+  previousVersions?: PackageVersions
   getVersionLabels?: (version: Key) => string[]
   isPublishing?: boolean
   extraValidationMassage?: string | null
@@ -157,6 +163,7 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
     packages,
     packagesTitle,
     versions,
+    previousVersionsPackageKey,
     previousVersions,
     getVersionLabels,
     packagePermissions,
@@ -197,6 +204,83 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
   const onLabelsChange = useCallback((_: SyntheticEvent, value: string[]): void => onSetTargetLabels?.(value), [onSetTargetLabels])
   const onStatusChange = useCallback((_: SyntheticEvent, value: VersionStatus): void => onSetTargetStatus?.(value), [onSetTargetStatus])
   const [warningApiProcessorState, setWarningApiProcessorState] = useState(false)
+
+  const previousVersionLabels = getPreviousVersionLabels(status)
+  const getPreviousVersionOptionLabel = useCallback((value: Key): string => (
+    value === NO_PREVIOUS_RELEASE_VERSION_OPTION
+      ? previousVersionLabels.noPreviousOptionLabel
+      : getSplittedVersionKey(value).versionKey
+  ), [previousVersionLabels])
+
+  const previousVersionStatuses = useMemo(() => getPreviousVersionStatuses(status), [status])
+
+  const [previousVersionSearch, setPreviousVersionSearch] = useState('')
+  const debouncedSetPreviousVersionSearch = useMemo(
+    () => debounce(setPreviousVersionSearch, DEFAULT_DEBOUNCE),
+    [],
+  )
+
+  const { versions: queriedPreviousVersions, areVersionsLoading: arePreviousVersionsLoading } = usePackageVersions({
+    packageKey: previousVersionsPackageKey,
+    status: previousVersionStatuses,
+    textFilter: previousVersionSearch,
+    enabled: !hidePreviousVersionField && !previousVersions && !!previousVersionsPackageKey,
+  })
+
+  const normalizedPreviousVersions = useMemo(
+    () => handleVersionsRevision(previousVersions ?? queriedPreviousVersions),
+    [previousVersions, queriedPreviousVersions],
+  )
+
+  const previousVersionStatusMap = useMemo(
+    () => new Map(normalizedPreviousVersions.map(({ key, status: versionStatus }) => [key, versionStatus])),
+    [normalizedPreviousVersions],
+  )
+
+  const [selectedPreviousVersionStatus, setSelectedPreviousVersionStatus] = useState<VersionStatus | undefined>()
+
+  useEffect(() => {
+    if (!previousVersion || previousVersion === NO_PREVIOUS_RELEASE_VERSION_OPTION) {
+      setSelectedPreviousVersionStatus(undefined)
+      return
+    }
+    const knownStatus = previousVersionStatusMap.get(previousVersion)
+    if (knownStatus) {
+      setSelectedPreviousVersionStatus(knownStatus)
+    }
+  }, [previousVersion, previousVersionStatusMap])
+
+  const getPreviousVersionOptionStatus = useCallback(
+    (versionKey: Key): VersionStatus | undefined =>
+      previousVersionStatusMap.get(versionKey) ??
+      (versionKey === previousVersion ? selectedPreviousVersionStatus : undefined),
+    [previousVersionStatusMap, previousVersion, selectedPreviousVersionStatus],
+  )
+
+  const previousVersionOptions = useMemo(() => {
+    const availableKeys = normalizedPreviousVersions.map(({ key }) => key)
+
+    const selectedButMissing =
+      previousVersion &&
+      previousVersion !== NO_PREVIOUS_RELEASE_VERSION_OPTION &&
+      !availableKeys.includes(previousVersion)
+
+    return [
+      NO_PREVIOUS_RELEASE_VERSION_OPTION,
+      ...(selectedButMissing ? [previousVersion] : []),
+      ...availableKeys,
+    ]
+  }, [normalizedPreviousVersions, previousVersion])
+
+  const hasInvalidPreviousVersionStatus = useMemo(() => {
+    if (!previousVersion || previousVersion === NO_PREVIOUS_RELEASE_VERSION_OPTION) {
+      return false
+    }
+    if (!selectedPreviousVersionStatus) {
+      return false
+    }
+    return !isPreviousVersionStatusAllowed(status, selectedPreviousVersionStatus)
+  }, [previousVersion, selectedPreviousVersionStatus, status])
 
   const debouncedOnWorkspacesChange = useMemo(() => debounce(onWorkspacesChange, DEFAULT_DEBOUNCE), [onWorkspacesChange])
   const debouncedOnPackagesChange = useMemo(() => debounce(onPackagesChange, DEFAULT_DEBOUNCE), [onPackagesChange])
@@ -677,20 +761,46 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
                 <Autocomplete
                   disabled={isPublishFieldsDisabled}
                   value={field.value ?? null}
-                  options={previousVersions ?? []}
-                  getOptionLabel={value => getSplittedVersionKey(value).versionKey}
+                  options={previousVersionOptions}
+                  loading={arePreviousVersionsLoading}
+                  filterOptions={disableAutocompleteSearch}
+                  onInputChange={createOnInputChange((_, value) => debouncedSetPreviousVersionSearch(value))}
+                  onClose={() => debouncedSetPreviousVersionSearch('')}
+                  getOptionLabel={getPreviousVersionOptionLabel}
                   isOptionEqualToValue={(option, value) => option === getSplittedVersionKey(value).versionKey}
                   renderOption={(props, versionKey) => (
-                    <ListItem {...props} key={versionKey}>
-                      {getSplittedVersionKey(versionKey).versionKey}
-                    </ListItem>
+                    <OptionItem
+                      key={versionKey}
+                      props={props}
+                      title={getPreviousVersionOptionLabel(versionKey)}
+                      chipValue={getPreviousVersionOptionStatus(versionKey)}
+                      chipVariant="filled"
+                      data-testid={`Option-${versionKey}`}
+                    />
                   )}
                   renderInput={(params) => (
                     <TextField
                       {...params}
                       required
-                      label="Previous release version"
-                      helperText={extraValidationMassage}
+                      label={previousVersionLabels.fieldLabel}
+                      error={hasInvalidPreviousVersionStatus}
+                      helperText={hasInvalidPreviousVersionStatus
+                        ? RELEASE_PREVIOUS_VERSION_REQUIRED_MESSAGE
+                        : extraValidationMassage}
+                      InputProps={{
+                        ...params.InputProps,
+                        endAdornment: (
+                          <>
+                            {previousVersion && getPreviousVersionOptionStatus(previousVersion) && (
+                              <CustomChip
+                                sx={{ mr: 0.5, height: '18px' }}
+                                value={getPreviousVersionOptionStatus(previousVersion)!}
+                              />
+                            )}
+                            {params.InputProps.endAdornment}
+                          </>
+                        ),
+                      }}
                     />
                   )}
                   onChange={(_, value) => {
@@ -724,7 +834,7 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
           variant="contained"
           type="submit"
           loading={isPublishing}
-          disabled={isFileReading || publishButtonDisabled || publishFieldsDisabled || warningApiProcessorState}
+          disabled={isFileReading || publishButtonDisabled || publishFieldsDisabled || warningApiProcessorState || hasInvalidPreviousVersionStatus}
           data-testid={submitButtonTittle ? `${submitButtonTittle}Button` : 'PublishButton'}
         >
           {submitButtonTittle ?? 'Publish'}
@@ -745,15 +855,6 @@ export function replaceEmptyPreviousVersion(previousVersion: Key): Key {
   return previousVersion === NO_PREVIOUS_RELEASE_VERSION_OPTION
     ? EMPTY_VERSION_KEY
     : previousVersion
-}
-
-export function usePreviousVersionOptions(versions: PackageVersions): VersionKey[] {
-  const versionsWithoutRevision = handleVersionsRevision(versions)
-
-  return useMemo(() => ([
-    NO_PREVIOUS_RELEASE_VERSION_OPTION,
-    ...versionsWithoutRevision.filter(({ status }) => status === RELEASE_VERSION_STATUS).map(({ key }) => key),
-  ]), [versionsWithoutRevision])
 }
 
 export function getVersionOptions(versionLabelsMap: Record<string, string[]>, targetVersion: string): VersionKey[] {

--- a/packages/shared/src/components/VersionDialogForm.tsx
+++ b/packages/shared/src/components/VersionDialogForm.tsx
@@ -136,7 +136,7 @@ export type VersionDialogFormProps<T extends VersionFormData = VersionFormData> 
   hidePreviousVersionField?: boolean
   publishButtonDisabled?: boolean
   publishFieldsDisabled?: boolean
-  currentPackageKey?: string
+  currentPackageKey?: Key
 }
 
 export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogFormProps>((props) => {
@@ -224,7 +224,7 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
     packageKey: previousVersionsPackageKey,
     status: previousVersionStatuses,
     textFilter: previousVersionSearch,
-    enabled: !hidePreviousVersionField && !previousVersions && !!previousVersionsPackageKey,
+    enabled: !hidePreviousVersionField && previousVersions === undefined && !!previousVersionsPackageKey,
   })
 
   const normalizedPreviousVersions = useMemo(
@@ -237,24 +237,37 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
     [normalizedPreviousVersions],
   )
 
-  const [selectedPreviousVersionStatus, setSelectedPreviousVersionStatus] = useState<VersionStatus | undefined>()
+  const [rememberedPreviousVersionStatus, setRememberedPreviousVersionStatus] =
+    useState<{ version: Key; status: VersionStatus } | undefined>()
 
   useEffect(() => {
     if (!previousVersion || previousVersion === NO_PREVIOUS_RELEASE_VERSION_OPTION) {
-      setSelectedPreviousVersionStatus(undefined)
+      setRememberedPreviousVersionStatus(undefined)
       return
     }
     const knownStatus = previousVersionStatusMap.get(previousVersion)
     if (knownStatus) {
-      setSelectedPreviousVersionStatus(knownStatus)
+      setRememberedPreviousVersionStatus({ version: previousVersion, status: knownStatus })
+      return
     }
+    setRememberedPreviousVersionStatus(remembered => (
+      remembered?.version === previousVersion ? remembered : undefined
+    ))
   }, [previousVersion, previousVersionStatusMap])
 
+  /**
+   * Single source for the status chip, used by the dropdown, the closed field and the validation.
+   *
+   * Order matters: the fetched list is consulted first, so a status changed on the server wins over
+   * the remembered one. The fallback applies only to the version the status was remembered for.
+   */
   const getPreviousVersionOptionStatus = useCallback(
     (versionKey: Key): VersionStatus | undefined =>
       previousVersionStatusMap.get(versionKey) ??
-      (versionKey === previousVersion ? selectedPreviousVersionStatus : undefined),
-    [previousVersionStatusMap, previousVersion, selectedPreviousVersionStatus],
+      (versionKey === rememberedPreviousVersionStatus?.version
+        ? rememberedPreviousVersionStatus.status
+        : undefined),
+    [previousVersionStatusMap, rememberedPreviousVersionStatus],
   )
 
   const previousVersionOptions = useMemo(() => {
@@ -276,11 +289,12 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
     if (!previousVersion || previousVersion === NO_PREVIOUS_RELEASE_VERSION_OPTION) {
       return false
     }
-    if (!selectedPreviousVersionStatus) {
+    const previousStatus = getPreviousVersionOptionStatus(previousVersion)
+    if (!previousStatus) {
       return false
     }
-    return !isPreviousVersionStatusAllowed(status, selectedPreviousVersionStatus)
-  }, [previousVersion, selectedPreviousVersionStatus, status])
+    return !isPreviousVersionStatusAllowed(status, previousStatus)
+  }, [previousVersion, getPreviousVersionOptionStatus, status])
 
   const debouncedOnWorkspacesChange = useMemo(() => debounce(onWorkspacesChange, DEFAULT_DEBOUNCE), [onWorkspacesChange])
   const debouncedOnPackagesChange = useMemo(() => debounce(onPackagesChange, DEFAULT_DEBOUNCE), [onPackagesChange])
@@ -778,31 +792,34 @@ export const VersionDialogForm: FC<VersionDialogFormProps> = memo<VersionDialogF
                       data-testid={`Option-${versionKey}`}
                     />
                   )}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      required
-                      label={previousVersionLabels.fieldLabel}
-                      error={hasInvalidPreviousVersionStatus}
-                      helperText={hasInvalidPreviousVersionStatus
-                        ? RELEASE_PREVIOUS_VERSION_REQUIRED_MESSAGE
-                        : extraValidationMassage}
-                      InputProps={{
-                        ...params.InputProps,
-                        endAdornment: (
-                          <>
-                            {previousVersion && getPreviousVersionOptionStatus(previousVersion) && (
-                              <CustomChip
-                                sx={{ mr: 0.5, height: '18px' }}
-                                value={getPreviousVersionOptionStatus(previousVersion)!}
-                              />
-                            )}
-                            {params.InputProps.endAdornment}
-                          </>
-                        ),
-                      }}
-                    />
-                  )}
+                  renderInput={(params) => {
+                    const selectedStatus = previousVersion
+                      ? getPreviousVersionOptionStatus(previousVersion)
+                      : undefined
+
+                    return (
+                      <TextField
+                        {...params}
+                        required
+                        label={previousVersionLabels.fieldLabel}
+                        error={hasInvalidPreviousVersionStatus}
+                        helperText={hasInvalidPreviousVersionStatus
+                          ? RELEASE_PREVIOUS_VERSION_REQUIRED_MESSAGE
+                          : extraValidationMassage}
+                        InputProps={{
+                          ...params.InputProps,
+                          endAdornment: (
+                            <>
+                              {selectedStatus && (
+                                <CustomChip sx={{ mr: 0.5, height: '18px' }} value={selectedStatus}/>
+                              )}
+                              {params.InputProps.endAdornment}
+                            </>
+                          ),
+                        }}
+                      />
+                    )
+                  }}
                   onChange={(_, value) => {
                     setValue('previousVersion', value ?? NO_PREVIOUS_RELEASE_VERSION_OPTION)
                     setSelectedPreviousVersion?.(value ?? NO_PREVIOUS_RELEASE_VERSION_OPTION)

--- a/packages/shared/src/entities/version-status.ts
+++ b/packages/shared/src/entities/version-status.ts
@@ -52,3 +52,42 @@ export const VERSION_STATUSES: VersionStatuses = [
 ]
 
 export const NO_PREVIOUS_RELEASE_VERSION_OPTION: Key = 'No previous release version'
+
+export const RELEASE_PREVIOUS_VERSION_REQUIRED_MESSAGE = 'A release version must have a release previous version'
+
+export type PreviousVersionLabels = {
+  fieldLabel: string
+  noPreviousOptionLabel: string
+}
+
+const DRAFT_PREVIOUS_VERSION_LABELS: PreviousVersionLabels = {
+  fieldLabel: 'Previous version',
+  noPreviousOptionLabel: 'No previous version',
+}
+
+const RELEASE_PREVIOUS_VERSION_LABELS: PreviousVersionLabels = {
+  fieldLabel: 'Previous release version',
+  noPreviousOptionLabel: 'No previous release version',
+}
+
+export function getPreviousVersionLabels(status: VersionStatus | undefined): PreviousVersionLabels {
+  return status === DRAFT_VERSION_STATUS
+    ? DRAFT_PREVIOUS_VERSION_LABELS
+    : RELEASE_PREVIOUS_VERSION_LABELS
+}
+
+export function getPreviousVersionStatuses(status: VersionStatus | undefined): VersionStatus[] {
+  return status === DRAFT_VERSION_STATUS
+    ? [RELEASE_VERSION_STATUS, DRAFT_VERSION_STATUS]
+    : [RELEASE_VERSION_STATUS]
+}
+
+export function isPreviousVersionStatusAllowed(
+  status: VersionStatus | undefined,
+  previousStatus: VersionStatus,
+): boolean {
+  if (status === DRAFT_VERSION_STATUS) {
+    return previousStatus === DRAFT_VERSION_STATUS || previousStatus === RELEASE_VERSION_STATUS
+  }
+  return previousStatus === RELEASE_VERSION_STATUS
+}

--- a/packages/shared/src/hooks/versions/usePackageVersions.ts
+++ b/packages/shared/src/hooks/versions/usePackageVersions.ts
@@ -44,7 +44,7 @@ type FetchNextVersionsList = (options?: FetchNextPageOptions) => Promise<Infinit
 // TODO 13.07.23 // Is there any more optimal way to do paged/flatten result?
 export function usePagedPackageVersions(options?: Partial<{
   packageKey: Key
-  status: VersionStatus
+  status: VersionStatus[]
   textFilter: string
   sortBy: PackageVersionsSortBy
   sortOrder: SortOrder
@@ -77,7 +77,7 @@ export function usePagedPackageVersions(options?: Partial<{
 
 export function usePackageVersions(options?: Partial<{
   packageKey: Key
-  status: VersionStatus
+  status: VersionStatus[]
   textFilter: string
   sortBy: PackageVersionsSortBy
   sortOrder: SortOrder
@@ -131,9 +131,13 @@ export function usePackageVersions(options?: Partial<{
   }
 }
 
+function toStatusQueryValue(statuses: VersionStatus[]): string {
+  return statuses.map(value => PUBLISH_STATUSES.get(value)!.toLowerCase()).join(',')
+}
+
 export async function getPackageVersionsList(
   packageKey: Key,
-  status?: VersionStatus,
+  status?: VersionStatus[],
   textFilter?: string,
   sortBy?: PackageVersionsSortBy,
   sortOrder?: SortOrder,
@@ -145,7 +149,7 @@ export async function getPackageVersionsList(
   const packageId = encodeURIComponent(packageKey)
 
   const queryParams = optionalSearchParams({
-    status: { value: status, toStringValue: (value) => PUBLISH_STATUSES.get(value.toString())!.toLowerCase() },
+    status: { value: status, toStringValue: (value) => toStatusQueryValue(value as VersionStatus[]) },
     limit: { value: limit },
     page: { value: page },
     textFilter: { value: textFilter },


### PR DESCRIPTION
## Summary

Aligns UI validation and previous-version selection with backend rules introduced in
[Netcracker/qubership-apihub-backend#322](https://github.com/Netcracker/qubership-apihub-backend/issues/322).

Closes [Netcracker/qubership-apihub#709](https://github.com/Netcracker/qubership-apihub/issues/709).

When publishing or copying a package version, the UI now enforces the same previous-version
status rules as the backend:

- **Release** versions must reference a **release** previous version.
- **Draft** versions may reference a previous version in **draft** or **release** status.
- Switching the target status to **release** re-validates the selected previous version and
  blocks submit when the combination is invalid.

## Changes

### Shared validation and labels (`version-status.ts`)
- Add helpers for status-dependent labels, allowed previous-version statuses, and validation:
  `getPreviousVersionLabels`, `getPreviousVersionStatuses`, `isPreviousVersionStatusAllowed`.
- Add shared error message: `A release version must have a release previous version`.

### `VersionDialogForm` (centralized behavior)
- Move previous-version fetching and option building into the shared form via
  `previousVersionsPackageKey` (replacing pre-built `previousVersions` option lists in callers).
- Filter available previous versions by the selected target status.
- Show version status chips in the dropdown and on the selected value.
- Use status-aware field labels:
  - **Draft:** “Previous version” / “No previous version”
  - **Release / archive:** “Previous release version” / “No previous release version”
- Re-validate when target status changes; highlight the field, show the error message, and
  disable Publish/Copy when a release version has a non-release previous version.
- Remember the previous version’s status so validation still works while options are refetched.

### Portal dialogs (simplified callers)
- **Publish Package Version**
- **Publish Dashboard Version from CSV**
- **Copy Package Version**
- **Publish Operation Group Package Version**

Each dialog now passes `previousVersionsPackageKey` instead of fetching release-only versions
and building options locally. Removed `usePreviousVersionOptions`.

### API hook update
- `usePackageVersions` / `getPackageVersionsList`: accept `status` as `VersionStatus[]` and
  serialize multiple statuses in the query string.

### Other
- `OptionItem`: add optional `chipVariant` for status chips in the previous-version dropdown.
- Storybook: wrap stories in `QueryClientProvider` so `VersionDialogForm` can render with
  internal queries disabled.
- Minor call-site updates in `VersionSelector`, `PackageVersionsTable`, and
  `GeneralPackageSettingsTabEditor` for the new status array API.

## Test plan

- [ ] **Publish (release):** previous-version dropdown lists only release versions; selecting
  a draft previous version is not possible.
- [ ] **Publish (draft):** previous-version dropdown lists both draft and release versions.
- [ ] **Status switch:** select a draft previous version, change target status to release —
  field shows error, Publish is disabled, message reads
  “A release version must have a release previous version”.
- [ ] **Status switch back:** change target status back to draft — error clears, Publish
  re-enables.
- [ ] **Copy Package Version:** same validation and filtering behavior as publish.
- [ ] **Publish from CSV:** same behavior for dashboard CSV publish flow.
- [ ] **Publish Operation Group:** same behavior when publishing an operation group version.
- [ ] **Labels:** draft uses “Previous version”; release uses “Previous release version”.
- [ ] **Search:** previous-version autocomplete supports text search and shows loading state.
- [ ] **Chips:** selected value and dropdown options display the correct version status.
- [ ] **Regression:** version selector and package settings version tables still load/filter
  correctly with the updated `status[]` API.
- [ ] **Storybook:** `VersionDialogForm` stories render without React Query errors.