### PR TITLE
fix: resolve previous package version for dashboard operation change details

### DIFF
--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionApiChangesSubPage/OperationChangesSubTableWrapper.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionApiChangesSubPage/OperationChangesSubTableWrapper.tsx
@@ -22,6 +22,7 @@ import type { SubTableComponentProps } from '@netcracker/qubership-apihub-ui-sha
 import { OperationChangesSubTable } from '@netcracker/qubership-apihub-ui-shared/widgets/ChangesViewWidget'
 import { usePackageVersionContent } from '@apihub/routes/root/usePackageVersionContent'
 import { sortChanges } from '@netcracker/qubership-apihub-ui-shared/utils/api-changes'
+import { DASHBOARD_KIND } from '@netcracker/qubership-apihub-ui-shared/entities/packages'
 
 export type OperationChangesSubTableWrapper = SubTableComponentProps
 
@@ -30,15 +31,32 @@ export const OperationChangesSubTableWrapper: FC<OperationChangesSubTableWrapper
     const { currentOperation, previousOperation } = value.original.change
     const operationKey = currentOperation?.operationKey ?? previousOperation!.operationKey
 
-    const { versionContent, isLoading: isVersionLoading } = usePackageVersionContent({ packageKey, versionKey })
+    const isDashboard = packageKind === DASHBOARD_KIND
+
+    // TODO(Operations/backend): The operations API lacks dashboard `refPackageId` support (unlike DDL).
+    // We use the referenced package's version from the dashboard config as a workaround.
+    // Refactor this to use the dashboard's own version once backend support is added.
+    const { versionContent, isLoading: isVersionLoading } = usePackageVersionContent({
+      packageKey: packageKey,
+      versionKey: versionKey,
+      enabled: !isDashboard,
+    })
+
+    const previousVersion = isDashboard
+      ? previousOperation?.packageRef?.version
+      : versionContent?.previousVersion
+
+    const previousVersionPackageId = isDashboard
+      ? (previousOperation?.packageRef?.key ?? packageKey)
+      : (versionContent?.previousVersionPackageId ?? packageKey)
 
     const [changes, isLoading] = useOperationChangelog({
       versionKey: versionKey!,
       packageKey: packageKey!,
       operationKey: operationKey!,
       apiType: apiType,
-      previousVersion: versionContent?.previousVersion,
-      previousVersionPackageId: versionContent?.previousVersionPackageId ?? packageKey,
+      previousVersion: previousVersion,
+      previousVersionPackageId: previousVersionPackageId,
       enable: true,
     })
 
@@ -47,7 +65,7 @@ export const OperationChangesSubTableWrapper: FC<OperationChangesSubTableWrapper
     return (
       <OperationChangesSubTable
         changes={sortedChanges}
-        isLoading={isLoading || isVersionLoading}
+        isLoading={isLoading || (!isDashboard && isVersionLoading)}
         packageKind={packageKind}
       />
     )

--- a/packages/portal/src/routes/root/PortalPage/VersionPage/VersionApiChangesSubPage/OperationChangesSubTableWrapper.tsx
+++ b/packages/portal/src/routes/root/PortalPage/VersionPage/VersionApiChangesSubPage/OperationChangesSubTableWrapper.tsx
@@ -57,7 +57,7 @@ export const OperationChangesSubTableWrapper: FC<OperationChangesSubTableWrapper
       apiType: apiType,
       previousVersion: previousVersion,
       previousVersionPackageId: previousVersionPackageId,
-      enable: true,
+      enable: !!previousVersion,
     })
 
     const sortedChanges = useMemo(() => sortChanges(changes), [changes])


### PR DESCRIPTION
Resolves an issue with fetching operation change details in dashboard views.

### Root Cause

The operations changelog API currently lacks `refPackageKey` support for dashboard contexts. Previously, `OperationChangesSubTableWrapper` fetched the default previous version directly from the target package itself via `usePackageVersionContent`. For dashboards configured with custom package version comparisons (e.g., 2026.2 -> 2025.2), this resulted in querying the wrong previous version, causing operation change details to fail to load.

### Key Changes

**OperationChangesSubTableWrapper**:
  - Added `isDashboard` check (`packageKind === DASHBOARD_KIND`).
  - For dashboard views, resolved `previousVersion` and `previousVersionPackageId` directly from `previousOperation.packageRef` instead of `usePackageVersionContent`.
  - Set `enabled: !isDashboard` on `usePackageVersionContent` to bypass redundant version queries.
  - Updated sub-table `isLoading` calculation to ignore `isVersionLoading` when `isDashboard` is true.
  - Added a `TODO` comment to refactor once backend operations API introduces dashboard `refPackageId` support.