### PR TITLE
fix: stop showing incorrect document name in publication error toast

### DIFF
--- a/packages/portal/src/routes/EventBusProvider.tsx
+++ b/packages/portal/src/routes/EventBusProvider.tsx
@@ -204,7 +204,6 @@ export type SelectCreatedCustomServerDetail = {
 export type RulesetInfoPopupDetails = RulesetMetadata
 
 export type ShowPublicationErrorReportDetail = {
-  documentName: string
   downloadFilename: string
   errors: string
 }

--- a/packages/portal/src/routes/root/PortalPage/usePublishPackageVersion.ts
+++ b/packages/portal/src/routes/root/PortalPage/usePublishPackageVersion.ts
@@ -35,7 +35,6 @@ import {
 } from '@netcracker/qubership-apihub-ui-shared/utils/packages-builder'
 import { isTokenRefreshed, onMutationUnauthorized } from '@netcracker/qubership-apihub-ui-shared/utils/security'
 import { getSplittedVersionKey } from '@netcracker/qubership-apihub-ui-shared/utils/versions'
-import { fileIdToDocumentName, fileIdToErrorReportFilename } from '@netcracker/qubership-apihub-ui-shared/utils/files'
 import { useMutation } from '@tanstack/react-query'
 import { useCallback } from 'react'
 import { useParams } from 'react-router-dom'

--- a/packages/portal/src/routes/root/PortalPage/usePublishPackageVersion.ts
+++ b/packages/portal/src/routes/root/PortalPage/usePublishPackageVersion.ts
@@ -62,19 +62,16 @@ export function usePublishPackageVersion(): [PublishPackageVersion, IsLoading, I
     errorMessage: string | undefined,
     files: BuildConfigFile[] | undefined,
   ) => {
-    const fileId = files?.[0]?.fileId
-    if (fileId) {
-      const documentName = fileIdToDocumentName(fileId)
-      const downloadFilename = fileIdToErrorReportFilename(fileId)
+    const fileIdLength = files?.length
+    if (fileIdLength) {
       const packageName = currentPackage?.name ?? packageId ?? ''
       showErrorNotification({
         title: 'Publication error',
-        message: `The ${documentName} document in the ${packageName} package was published with errors.`,
+        message: `There was an error while publishing package ${packageName}`,
         button: {
           title: 'View details',
           onClick: () => showPublicationErrorReportDialog({
-            documentName,
-            downloadFilename,
+            downloadFilename: `Error report for the package ${packageName}`,
             errors: errorMessage ?? '',
           }),
         },

--- a/packages/portal/src/routes/root/PortalPage/usePublishPackageVersion.ts
+++ b/packages/portal/src/routes/root/PortalPage/usePublishPackageVersion.ts
@@ -62,8 +62,8 @@ export function usePublishPackageVersion(): [PublishPackageVersion, IsLoading, I
     errorMessage: string | undefined,
     files: BuildConfigFile[] | undefined,
   ) => {
-    const fileIdLength = files?.length
-    if (fileIdLength) {
+    const filesListLength = files?.length
+    if (filesListLength) {
       const packageName = currentPackage?.name ?? packageId ?? ''
       showErrorNotification({
         title: 'Publication error',


### PR DESCRIPTION
## Summary

Fixes inconsistent publication error messaging when publishing a package with multiple specifications.

Previously, the error toast named the first file in the publish list (`files[0]`), while the "View details" dialog showed the actual parse error for a different file. This change replaces the misleading file-specific toast with a package-level message and removes the unused `documentName` field from the publication error report event type.

Closes Netcracker/qubership-apihub#758

## Problem

When publishing a package with several specifications (some invalid):

- **Toast:** "The markdown-sample.md document in the Test service package was published with errors."
- **Details dialog:** "Cannot parse file openapi.yaml. Missing closing 'quote…"

The toast referenced the wrong document because it inferred the failing file from `files[0].fileId`, not from the actual error.

## Solution

- Use a package-level notification message: `There was an error while publishing package {packageName}`
- Gate the rich error UI on `files?.length` instead of `files[0].fileId`
- Use a package-level download filename for the error report
- Remove unused `documentName` from `ShowPublicationErrorReportDetail` (it was never consumed by the dialog)
- Remove unused `fileIdToDocumentName` / `fileIdToErrorReportFilename` imports

## Test plan

- [ ] Create a package with multiple specification files, including at least one invalid file (e.g. the repro from #758)
- [ ] Publish the package and confirm the error toast shows a package-level message (no incorrect document name)
- [ ] Click **View details** and confirm the dialog shows the actual parse error for the problematic file
- [ ] Verify the error report can be copied and downloaded
- [ ] Publish a package with no files and confirm the fallback plain error notification still works