### PR TITLE
fix: DDL publish via dev proxy is not working

### DIFF
--- a/packages/agents/vite.config.ts
+++ b/packages/agents/vite.config.ts
@@ -78,17 +78,6 @@ export default defineConfig(({ mode }) => {
       include: [
         '@netcracker/qubership-apihub-api-processor',
       ],
-      // ddlapi must be pre-bundled rather than excluded. Its browser build reads the DDL source
-      // through `Buffer` (`Buffer.from(ddl, 'utf8')` in `prepareDdlExtractor`, and the whole span
-      // engine operates on that buffer) but references it as a bare global, because the bundle
-      // targets Node. `NodeGlobalsPolyfill` below supplies that global, and it only reaches
-      // packages that go through pre-bundling — excluding ddlapi left it without one, so publishing
-      // a DDL document failed with "Buffer is not defined" on the dev server only.
-      // See https://github.com/Netcracker/qubership-apihub/issues/743.
-      //
-      // Excluding it bought nothing in return: `optimizeDeps` applies to the dev server alone, so it
-      // has no say in how the production build chunks the WASM-inlined '/parser'. That is decided by
-      // rollup, where the parser stays in the lazily-loaded build-worker chunk either way.
       esbuildOptions: {
         plugins: [
           NodeModulesPolyfill(),

--- a/packages/agents/vite.config.ts
+++ b/packages/agents/vite.config.ts
@@ -78,12 +78,17 @@ export default defineConfig(({ mode }) => {
       include: [
         '@netcracker/qubership-apihub-api-processor',
       ],
-      // Keep ddlapi out of esbuild pre-bundling so its self-contained '/parser'
-      // (WASM-inlined) stays in the build worker's lazily-loaded chunk rather than
-      // being eagerly pre-bundled. Reached only via api-processor/processor.
-      exclude: [
-        '@netcracker/qubership-apihub-ddlapi',
-      ],
+      // ddlapi must be pre-bundled rather than excluded. Its browser build reads the DDL source
+      // through `Buffer` (`Buffer.from(ddl, 'utf8')` in `prepareDdlExtractor`, and the whole span
+      // engine operates on that buffer) but references it as a bare global, because the bundle
+      // targets Node. `NodeGlobalsPolyfill` below supplies that global, and it only reaches
+      // packages that go through pre-bundling — excluding ddlapi left it without one, so publishing
+      // a DDL document failed with "Buffer is not defined" on the dev server only.
+      // See https://github.com/Netcracker/qubership-apihub/issues/743.
+      //
+      // Excluding it bought nothing in return: `optimizeDeps` applies to the dev server alone, so it
+      // has no say in how the production build chunks the WASM-inlined '/parser'. That is decided by
+      // rollup, where the parser stays in the lazily-loaded build-worker chunk either way.
       esbuildOptions: {
         plugins: [
           NodeModulesPolyfill(),

--- a/packages/portal/vite.config.ts
+++ b/packages/portal/vite.config.ts
@@ -85,12 +85,17 @@ export default defineConfig(({ mode }) => {
       include: [
         '@netcracker/qubership-apihub-api-processor',
       ],
-      // Keep ddlapi out of esbuild pre-bundling so its self-contained '/parser'
-      // (WASM-inlined) stays in the build worker's lazily-loaded chunk rather than
-      // being eagerly pre-bundled. Reached only via api-processor/processor.
-      exclude: [
-        '@netcracker/qubership-apihub-ddlapi',
-      ],
+      // ddlapi must be pre-bundled rather than excluded. Its browser build reads the DDL source
+      // through `Buffer` (`Buffer.from(ddl, 'utf8')` in `prepareDdlExtractor`, and the whole span
+      // engine operates on that buffer) but references it as a bare global, because the bundle
+      // targets Node. `NodeGlobalsPolyfill` below supplies that global, and it only reaches
+      // packages that go through pre-bundling — excluding ddlapi left it without one, so publishing
+      // a DDL document failed with "Buffer is not defined" on the dev server only.
+      // See https://github.com/Netcracker/qubership-apihub/issues/743.
+      //
+      // Excluding it bought nothing in return: `optimizeDeps` applies to the dev server alone, so it
+      // has no say in how the production build chunks the WASM-inlined '/parser'. That is decided by
+      // rollup, where the parser stays in the lazily-loaded build-worker chunk either way.
       esbuildOptions: {
         plugins: [
           NodeModulesPolyfill(),

--- a/packages/portal/vite.config.ts
+++ b/packages/portal/vite.config.ts
@@ -85,17 +85,6 @@ export default defineConfig(({ mode }) => {
       include: [
         '@netcracker/qubership-apihub-api-processor',
       ],
-      // ddlapi must be pre-bundled rather than excluded. Its browser build reads the DDL source
-      // through `Buffer` (`Buffer.from(ddl, 'utf8')` in `prepareDdlExtractor`, and the whole span
-      // engine operates on that buffer) but references it as a bare global, because the bundle
-      // targets Node. `NodeGlobalsPolyfill` below supplies that global, and it only reaches
-      // packages that go through pre-bundling — excluding ddlapi left it without one, so publishing
-      // a DDL document failed with "Buffer is not defined" on the dev server only.
-      // See https://github.com/Netcracker/qubership-apihub/issues/743.
-      //
-      // Excluding it bought nothing in return: `optimizeDeps` applies to the dev server alone, so it
-      // has no say in how the production build chunks the WASM-inlined '/parser'. That is decided by
-      // rollup, where the parser stays in the lazily-loaded build-worker chunk either way.
       esbuildOptions: {
         plugins: [
           NodeModulesPolyfill(),


### PR DESCRIPTION
### Why `optimizeDeps.exclude` was dropped for ddlapi

`optimizeDeps` configures the dev server's dependency pre-bundling. It takes no part in
`vite build` — production chunking is decided by rollup. The exclusion therefore could not
protect anything in the production bundle, and the old comment ("keep the WASM-inlined parser
in the lazily-loaded worker chunk") described a concern `optimizeDeps` has no say over.

Verified empirically. Two production builds, before and after removing the exclusion:

    files:                       191 / 191
    name sets (content-hashed):  identical
    files differing by SHA-256:  0

Byte-for-byte identical output. The parser stays where it was — `libpg-query.wasm` appears
only in `package-version-builder-worker-*.js` (3.6 MB), never in the entry chunk, and that
chunk is still fetched lazily via `new Worker("/assets/package-version-builder-worker-*.js")`
on first publish.

What the exclusion *did* do was cut ddlapi off from `NodeGlobalsPolyfill({ buffer: true })`,
applied through `optimizeDeps.esbuildOptions`. ddlapi's browser build reads the DDL source
through `Buffer` (`Buffer.from(ddl, 'utf8')` in `prepareDdlExtractor`; the whole span engine
operates on that buffer) but references it as a bare global, since the bundle targets Node.
In production `@rollup/plugin-inject` rewrites that identifier into an import — which is why
only the dev server was affected, exactly as reported in #743.

### Why not polyfill `buffer` in the worker instead

Tried and reverted. `resolve.alias` maps `'buffer'` to an absolute file path, and aliases
resolve before the dep optimizer, so `import { Buffer } from 'buffer'` was served as raw
CommonJS. An ES module worker cannot load that: it died during module evaluation, never
registered a thread in DevTools, and Chrome reported an empty `ErrorEvent`.

Letting the existing esbuild polyfill do its job requires no application code at all.

### Trade-off

Dev-server startup now pre-bundles ddlapi (~1.9 MB, WASM inlined), so the first
"optimizing dependencies" pass is slower. Cached afterwards. No production impact.